### PR TITLE
net: ethernet: silicom: Fix license specification

### DIFF
--- a/drivers/net/ethernet/silicom/n5010-phy.c
+++ b/drivers/net/ethernet/silicom/n5010-phy.c
@@ -232,4 +232,4 @@ module_platform_driver(n5010_phy_driver);
 MODULE_DEVICE_TABLE(platform, n5010_phy_ids);
 MODULE_AUTHOR("Intel Corporation");
 MODULE_DESCRIPTION("Intel MAX10 BMC phy driver for n5010");
-MODULE_LICENSE("GPL");
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
Change MODULE_LICENSE("GPL") to MODULE_LICENSE("GPL v2").

Signed-off-by: Russ Weight <russell.h.weight@intel.com>