### PR TITLE
n5010 fpga-ofs-dev-5.10-lts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@ RPMBUILDOPTS = -bb --build-in-place \
                --define '_modules $(reverse)'
 
 ifeq ($(BACKPORT_VERSION),)
+ifneq ($(wildcard .git),)
 BACKPORT_VERSION := $(shell git describe --always --tags --dirty --long | sed -E 's/^v//;s/([^-]*-g)/r\1/;s/-/./g;s/\.rc/rc/')
+endif
 endif
 
 export BACKPORT_VERSION

--- a/Makefile
+++ b/Makefile
@@ -118,17 +118,14 @@ clean:
 $(rules_rmmod): rmmod_%:
 	@if lsmod | grep -qE '\<$*\>'; then rmmod $*; fi
 
-# Needed for uio_dfl
-modprobe_uio:
-	@modprobe uio
-
 $(rules_insmod): insmod_%:
 	@if ! lsmod | grep -q $* && test -f $*.ko; then \
+		[ $* = uio-dfl ] && modprobe uio; \
 		insmod $*.ko $(DYNDBG); \
 	fi
 
 rmmod: $(rules_rmmod)
-insmod: modprobe_uio $(rules_insmod)
+insmod: $(rules_insmod)
 reload: rmmod insmod
 
 # helper used to generate dynamic dkms config based on kernel config

--- a/drivers/fpga/dfl-hssi.c
+++ b/drivers/fpga/dfl-hssi.c
@@ -191,6 +191,7 @@ static struct dfl_driver dfl_hssi_driver = {
 
 module_dfl_driver(dfl_hssi_driver);
 
+MODULE_ALIAS("dfl:t0000f000A");
 MODULE_DEVICE_TABLE(dfl, dfl_hssi_ids);
 MODULE_DESCRIPTION("DFL HSSI driver");
 MODULE_AUTHOR("Intel Corporation");

--- a/drivers/fpga/dfl-intel-s10-iopll.c
+++ b/drivers/fpga/dfl-intel-s10-iopll.c
@@ -551,6 +551,7 @@ static struct dfl_driver dfl_intel_s10_iopll_driver = {
 
 module_dfl_driver(dfl_intel_s10_iopll_driver);
 
+MODULE_ALIAS("dfl:t0001f0014");
 MODULE_DEVICE_TABLE(dfl, dfl_intel_s10_iopll_ids);
 MODULE_DESCRIPTION("DFL Intel S10 IOPLL driver");
 MODULE_AUTHOR("Intel Corporation");

--- a/drivers/fpga/dfl-n3000-nios.c
+++ b/drivers/fpga/dfl-n3000-nios.c
@@ -597,6 +597,7 @@ static struct dfl_driver n3000_nios_driver = {
 
 module_dfl_driver(n3000_nios_driver);
 
+MODULE_ALIAS("dfl:t0000f000D");
 MODULE_DESCRIPTION("Driver for Nios private feature on Intel PAC N3000");
 MODULE_AUTHOR("Intel Corporation");
 MODULE_LICENSE("GPL v2");

--- a/drivers/memory/dfl-emif.c
+++ b/drivers/memory/dfl-emif.c
@@ -239,6 +239,7 @@ static const struct dfl_device_id dfl_emif_ids[] = {
 	{ FME_ID, FME_FEATURE_ID_EMIF },
 	{ }
 };
+MODULE_ALIAS("dfl:t0000f0009");
 MODULE_DEVICE_TABLE(dfl, dfl_emif_ids);
 
 static struct dfl_driver dfl_emif_driver = {

--- a/drivers/net/ethernet/intel/s10hssi.c
+++ b/drivers/net/ethernet/intel/s10hssi.c
@@ -607,6 +607,7 @@ static struct dfl_driver s10hssi_mac_driver = {
 };
 
 module_dfl_driver(s10hssi_mac_driver);
+MODULE_ALIAS("dfl:t0000f000F");
 MODULE_DEVICE_TABLE(dfl, s10hssi_mac_ids);
 MODULE_DESCRIPTION("Network Device Driver for Intel(R) Startix10 HSSI");
 MODULE_AUTHOR("Intel Corporation");

--- a/drivers/uio/uio_dfl.c
+++ b/drivers/uio/uio_dfl.c
@@ -11,37 +11,27 @@
 #include <linux/module.h>
 #include <linux/spinlock.h>
 #include <linux/uio_driver.h>
+#include <linux/version.h>
 
-#define DRIVER_NAME "uio_dfl"
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 7, 0)
 
-#ifndef devm_uio_register_device
 static void devm_uio_unregister_device(struct device *dev, void *res)
 {
 	uio_unregister_device(*(struct uio_info **)res);
 }
 
-/**
- * __devm_uio_register_device - Resource managed uio_register_device()
- * @owner:	module that creates the new device
- * @parent:	parent device
- * @info:	UIO device capabilities
- *
- * returns zero on success or a negative error code.
- */
-static int __devm_uio_register_device(struct module *owner,
-				      struct device *parent,
-				      struct uio_info *info)
+static int devm_uio_register_device(struct device *parent, struct uio_info *info)
 {
 	struct uio_info **ptr;
 	int ret;
 
 	ptr = devres_alloc(devm_uio_unregister_device, sizeof(*ptr),
-			   GFP_KERNEL);
+			GFP_KERNEL);
 	if (!ptr)
 		return -ENOMEM;
 
 	*ptr = info;
-	ret = __uio_register_device(owner, parent, info);
+	ret = __uio_register_device(THIS_MODULE, parent, info);
 	if (ret) {
 		devres_free(ptr);
 		return ret;
@@ -52,18 +42,9 @@ static int __devm_uio_register_device(struct module *owner,
 	return 0;
 }
 
-/* use a define to avoid include chaining to get THIS_MODULE */
+#endif /* < KERNEL_VERSION(5, 7, 0) */
 
-/**
- * devm_uio_register_device - Resource managed uio_register_device()
- * @parent:	parent device
- * @info:	UIO device capabilities
- *
- * returns zero on success or a negative error code.
- */
-#define devm_uio_register_device(parent, info) \
-	__devm_uio_register_device(THIS_MODULE, parent, info)
-#endif
+#define DRIVER_NAME "uio_dfl"
 
 struct uio_dfl_dev {
 	struct device *dev;

--- a/include/linux/pci_ids.h
+++ b/include/linux/pci_ids.h
@@ -9,8 +9,4 @@
 #define PCI_VENDOR_ID_SILICOM_DENMARK	0x1c2c
 #endif
 
-#ifndef PCI_STD_NUM_BARS
-#define PCI_STD_NUM_BARS       6       /* Number of standard BARs */
-#endif
-
 #endif

--- a/include/uapi/linux/pci_regs.h
+++ b/include/uapi/linux/pci_regs.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __BACKPORT_PCI_REGS_H
+#define __BACKPORT_PCI_REGS_H
+
+#include_next <uapi/linux/pci_regs.h>
+
+#ifndef PCI_STD_NUM_BARS
+#define PCI_STD_NUM_BARS       6       /* Number of standard BARs */
+#endif
+
+#endif

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -22,8 +22,13 @@ import() {
 }
 
 apply() {
-  git rev-list --reverse --first-parent --no-merges --invert-grep --grep REVERTME --grep DEBUG $range | \
-    git cherry-pick --strategy recursive --strategy-option no-renames --stdin
+    git cherry-pick \
+      --strategy recursive \
+      --strategy-option no-renames \
+      --first-parent \
+      --no-merges \
+      --invert-grep --grep REVERTME --grep DEBUG \
+      $range
 }
 
 remote mainline git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -17,6 +17,7 @@ remote() {
 
 import() {
   git restore --pathspec-from-file $manifest --source $revision
+  git restore .
   git add .
   git commit -m "Import from mainline $revision"
 }

--- a/scripts/manifest.v5.10
+++ b/scripts/manifest.v5.10
@@ -65,6 +65,8 @@ drivers/net/phy/Makefile
 drivers/spi/Kconfig
 drivers/spi/Makefile
 drivers/spi/spi-altera.c
+drivers/uio/Kconfig
+drivers/uio/Makefile
 include/linux/fpga/adi-axi-common.h
 include/linux/fpga/altera-pr-ip-core.h
 include/linux/fpga/fpga-bridge.h


### PR DESCRIPTION
A few reverts and then cherry-picks from n5010/fpga-ofs-dev-5.10-lts.

The most interesting changes are probably:

1.  052e3e8a77ec - build: dkms: auto-generate list of modules to install
2.  4a1e1f6b4157 - Import from mainline v5.10.27

Commit 052e3e8a77ec makes DKMS generate a list of built modules to install. This both eases backports (because we don't need to maintain dkms.conf), and it allows us to conditonally build modules. The latter is important for the upcoming drivers for n6010 (Arrow Creek), which depends on regmap-mmio.

Commit 4a1e1f6b4157 adds regmap-mmio to the backport, as it is needed by n6010 (Arrow Creek), but isn't included in RHEL8x kernels.