### PR TITLE
uio: dfl: add HSSI feature id

### DIFF
--- a/drivers/uio/uio_dfl.c
+++ b/drivers/uio/uio_dfl.c
@@ -183,9 +183,11 @@ static int uio_dfl_probe(struct dfl_device *ddev)
 }
 
 #define FME_FEATURE_ID_ETH_GROUP	0x10
+#define FME_FEATURE_ID_OFS_HSSI		0x15
 
 static const struct dfl_device_id uio_dfl_ids[] = {
 	{ FME_ID, FME_FEATURE_ID_ETH_GROUP },
+	{ FME_ID, FME_FEATURE_ID_OFS_HSSI },
 	{ }
 };
 MODULE_DEVICE_TABLE(dfl, uio_dfl_ids);


### PR DESCRIPTION
Add the feature id of the OFS High Speed Serial Interface
subsystem to table of ids supported by the uio_dfl driver.

Signed-off-by: Matthew Gerlach <matthew.gerlach@linux.intel.com>