### PR TITLE
rhel: do not use sysfs_emit fallback after rhel 8.4

### DIFF
--- a/include/linux/sysfs.h
+++ b/include/linux/sysfs.h
@@ -7,7 +7,7 @@
 #include <linux/mm.h>
 #include_next <linux/sysfs.h>
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0) && RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8,5)
 /**
  *	sysfs_emit - scnprintf equivalent, aware of PAGE_SIZE buffer
  *	@buf:	start of PAGE_SIZE buffer.


### PR DESCRIPTION
RHEL 8.5 starts to use the sysfs_emit, so it is not
necessary to use the fallback.

Signed-off-by: Tom Rix <trix@redhat.com>