### PR TITLE
mfd: intel-m10-bmc: fix pmci flash reads

### DIFF
--- a/drivers/mfd/intel-m10-bmc-pmci.c
+++ b/drivers/mfd/intel-m10-bmc-pmci.c
@@ -130,9 +130,9 @@ pmci_flash_bulk_read(struct intel_m10bmc *m10bmc, void *buf,
 
 		size -= blk_size;
 		offset += blk_size;
-	}
 
-	writel(0, pmci->base + PMCI_FLASH_CTRL);
+		writel(0, pmci->base + PMCI_FLASH_CTRL);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Fix the flash read sequence to resolve read-back data of 0xdeadbeef

Signed-off-by: Tianfei Zhang <tianfei.zhang@intel.com>