### PR TITLE
fpga: dfl: Avoid reads to AFU CSRs during enumeration

### DIFF
--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -1035,16 +1035,18 @@ create_feature_instance(struct build_feature_devs_info *binfo,
 {
 	unsigned int irq_base, nr_irqs;
 	struct dfl_feature_info *finfo;
+	u8 rev = 0;
 	int ret;
-	u8 rev;
 	u64 v;
 
-	v = readq(binfo->ioaddr + ofst);
-	rev = FIELD_GET(DFH_REVISION, v);
+	if (fid != FEATURE_ID_AFU) {
+		v = readq(binfo->ioaddr + ofst);
+		rev = FIELD_GET(DFH_REVISION, v);
 
-	/* read feature size and id if inputs are invalid */
-	size = size ? size : feature_size(v);
-	fid = fid ? fid : feature_id(v);
+		/* read feature size and id if inputs are invalid */
+		size = size ? size : feature_size(v);
+		fid = fid ? fid : feature_id(v);
+	}
 
 	if (binfo->len - ofst < size)
 		return -EINVAL;


### PR DESCRIPTION
CSR address space for Accelerator Functional Units (AFU) is not available
during the early Device Feature List (DFL) enumeration. Early access
to this space results in invalid data and port errors. This change adds
a condition to prevent an early read from the AFU CSR space.

Signed-off-by: Russ Weight <russell.h.weight@intel.com>

Fixes: 1604986c3e6b ("fpga: dfl: expose feature revision from struct dfl_device")
Cc: stable@vger.kernel.org