### PR TITLE
uio: dfl: add id for feature with a GUID

### DIFF
--- a/drivers/uio/uio_dfl.c
+++ b/drivers/uio/uio_dfl.c
@@ -133,10 +133,12 @@ static int uio_dfl_probe(struct dfl_device *ddev)
 
 #define FME_FEATURE_ID_ETH_GROUP	0x10
 #define FME_FEATURE_ID_OFS_HSSI		0x15
+#define FME_FEATURE_ID_OFS_GUID		0x23
 
 static const struct dfl_device_id uio_dfl_ids[] = {
 	{ FME_ID, FME_FEATURE_ID_ETH_GROUP },
 	{ FME_ID, FME_FEATURE_ID_OFS_HSSI },
+	{ FME_ID, FME_FEATURE_ID_OFS_GUID },
 	{ }
 };
 MODULE_DEVICE_TABLE(dfl, uio_dfl_ids);


### PR DESCRIPTION
Add id for device feature list (dfl) feature that has a GUID
to table of ids supported by the uio_dfl driver.

Signed-off-by: Matthew Gerlach <matthew.gerlach@linux.intel.com>