### PR TITLE
mfd: intel-m10-bmc: fix concurrency issue

### DIFF
--- a/drivers/mfd/intel-m10-bmc-core.c
+++ b/drivers/mfd/intel-m10-bmc-core.c
@@ -183,7 +183,7 @@ m10bmc_pmci_flash_read(struct intel_m10bmc *m10bmc, void *buffer,
 
 	ret = m10bmc_pmci_get_mux(m10bmc);
 	if (ret)
-		return ret;
+		goto fail;
 
 	ret = m10bmc->flash_ops->read_blk(m10bmc, buffer, addr, size);
 	if (ret)
@@ -193,6 +193,8 @@ m10bmc_pmci_flash_read(struct intel_m10bmc *m10bmc, void *buffer,
 
 read_fail:
 	m10bmc_pmci_put_mux(m10bmc);
+fail:
+	mutex_unlock(&m10bmc->flash_ops->mux_lock);
 	return ret;
 }
 


### PR DESCRIPTION
There is an concurrency issue reported that read the flash content when
flashing the fpga image.

The root cause is that the m10bmc_pmci_set_flash_host_mux() function will
fail when flashing the fpga image, because this is hardware concurrency
mechanism. After m10bmc_pmci_set_flash_host_mux() fail, we should release
the mutex lock before return error.

Signed-off-by: Tianfei Zhang <tianfei.zhang@intel.com>