### PR TITLE
fix concurrency issue

### DIFF
--- a/drivers/mfd/intel-m10-bmc-core.c
+++ b/drivers/mfd/intel-m10-bmc-core.c
@@ -183,7 +183,7 @@ m10bmc_pmci_flash_read(struct intel_m10bmc *m10bmc, void *buffer,
 
 	ret = m10bmc_pmci_get_mux(m10bmc);
 	if (ret)
-		return ret;
+		goto read_fail;
 
 	ret = m10bmc->flash_ops->read_blk(m10bmc, buffer, addr, size);
 	if (ret)

--- a/drivers/mfd/intel-m10-bmc-log.c
+++ b/drivers/mfd/intel-m10-bmc-log.c
@@ -116,8 +116,8 @@ static int bmc_nvmem_read(struct m10bmc_log *ddata, unsigned int addr,
 	ret = ddata->m10bmc->ops.flash_read(ddata->m10bmc, val,
 					    addr + off, count);
 	if (ret) {
-		dev_err(ddata->dev, "failed to read flash %x\n", addr);
-		return -EIO;
+		dev_err(ddata->dev, "failed to read flash %x (%d)\n", addr, ret);
+		return ret;
 	}
 
 	return 0;


### PR DESCRIPTION
fix concurrency issue

There is an concurrency issue reported that read the flash content when
flashing the fpga image.

The root cause is that the m10bmc_pmci_set_flash_host_mux() function will
fail when flashing the fpga image, because this is hardware concurrency
mechanism. After m10bmc_pmci_set_flash_host_mux() fail, we should release
the mutex lock before return error.