### PR TITLE
fpga: intel-m10-bmc-sec-update: fix missing bracket

### DIFF
--- a/drivers/fpga/intel-m10-bmc-sec-update.c
+++ b/drivers/fpga/intel-m10-bmc-sec-update.c
@@ -1486,7 +1486,7 @@ static int m10bmc_sec_probe(struct platform_device *pdev)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0) && RHEL_RELEASE_CODE < 0x803
 	ret = device_add_groups(sec->dev, m10bmc_sec_attr_groups);
-	if (ret)
+	if (ret) {
 		dev_err(sec->dev, "Secure update driver failed to start\n");
 		firmware_upload_unregister(sec->fwl);
 		kfree(sec->fw_name);


### PR DESCRIPTION
Added missing bracket in the BMC secure update driver when
compiling for RHEL < 8.3

Signed-off-by: Marco Pagani <marpagan@redhat.com>