### PR TITLE
uio: dfl: add id for PCI Subsystem

### DIFF
--- a/drivers/uio/uio_dfl.c
+++ b/drivers/uio/uio_dfl.c
@@ -165,12 +165,14 @@ static int uio_dfl_probe(struct dfl_device *ddev)
 
 #define FME_FEATURE_ID_ETH_GROUP	0x10
 #define FME_FEATURE_ID_HSSI_SUBSYS	0x15
+#define FME_FEATURE_ID_PCI_SUBSYS	0x20
 #define FME_FEATURE_ID_OFS_GUID		0x23
 #define PORT_FEATURE_ID_IOPLL_USRCLK	0x14
 
 static const struct dfl_device_id uio_dfl_ids[] = {
 	{ FME_ID, FME_FEATURE_ID_ETH_GROUP },
 	{ FME_ID, FME_FEATURE_ID_HSSI_SUBSYS },
+	{ FME_ID, FME_FEATURE_ID_PCI_SUBSYS },
 	{ FME_ID, FME_FEATURE_ID_OFS_GUID },
 	{ PORT_ID, PORT_FEATURE_ID_IOPLL_USRCLK },
 	{ }


### PR DESCRIPTION
Add id for device feature list (dfl) PCI subsystem feature to table of ids supported by the uio_dfl driver.

Signed-off-by: Matthew Gerlach <matthew.gerlach@linux.intel.com>
(cherry picked from commit f65b0a5769b99db7b0e284db430c08a66228a2a1)