### PR TITLE
Allow driver build on Ubuntu 20.04

### DIFF
--- a/include/linux/sysfs.h
+++ b/include/linux/sysfs.h
@@ -7,7 +7,7 @@
 #include <linux/mm.h>
 #include_next <linux/sysfs.h>
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0) && RHEL_RELEASE_CODE < 0x805
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 104) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))) && RHEL_RELEASE_CODE < 0x805
 /**
  *	sysfs_emit - scnprintf equivalent, aware of PAGE_SIZE buffer
  *	@buf:	start of PAGE_SIZE buffer.


### PR DESCRIPTION
Kernel 5.4.104 includes sysfs_exit(), so it shall not be defined in backport for 5.4 from this.

Signed-off-by: Roger Christensen <rc@silicom.dk>