### PR TITLE
fpga: prevent integer overflow in dfl_feature_ioctl_set_irq()

### DIFF
--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -1916,7 +1916,7 @@ long dfl_feature_ioctl_set_irq(struct platform_device *pdev,
 		return -EINVAL;
 
 	fds = memdup_user((void __user *)(arg + sizeof(hdr)),
-			  hdr.count * sizeof(s32));
+			  array_size(hdr.count, sizeof(s32)));
 	if (IS_ERR(fds))
 		return PTR_ERR(fds);
 


### PR DESCRIPTION
The "hdr.count * sizeof(s32)" multiplication can overflow on 32 bit systems leading to memory corruption.  Use array_size() to fix that.

Fixes: 322b598be4d9 ("fpga: dfl: introduce interrupt trigger setting API")
Signed-off-by: Dan Carpenter <dan.carpenter@oracle.com>
Acked-by: Xu Yilun <yilun.xu@intel.com>
Link: https://lore.kernel.org/r/YxBAtYCM38dM7yzI@kili
Signed-off-by: Xu Yilun <yilun.xu@intel.com>
(cherry picked from commit 939bc5453b8cbdde9f1e5110ce8309aedb1b501a)