### PR TITLE
backport: change dev_err_probe to dev_err for older kernels

### DIFF
--- a/drivers/net/phy/qsfp-mem-dfl.c
+++ b/drivers/net/phy/qsfp-mem-dfl.c
@@ -29,7 +29,11 @@ static int qsfp_dfl_probe(struct dfl_device *dfl_dev)
 
 	ret = qsfp_init_work(qsfp);
 	if (ret) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x803
+		dev_err(dev,
+#else
 		dev_err_probe(dev, ret,
+#endif
 			      "Failed to initialize delayed work to read QSFP\n");
 		goto exit;
 	}

--- a/drivers/net/phy/qsfp-mem-platform.c
+++ b/drivers/net/phy/qsfp-mem-platform.c
@@ -53,7 +53,11 @@ static int qsfp_platform_probe(struct platform_device *pdev)
 
 	ret = qsfp_init_work(qsfp);
 	if (ret) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x803
+		dev_err(dev,
+#else
 		dev_err_probe(dev, ret,
+#endif
 			      "Failed to initialize delayed work to read QSFP\n");
 		goto exit;
 	}


### PR DESCRIPTION
The dev_err_probe() function was added to the linux kernel starting with 5.9. In the qsfp_mem driver, dev_err_probe() is only used for the print function. For pre 5.9 kernels, change to dev_err().

Signed-off-by: Russ Weight <russell.h.weight@intel.com>