### PR TITLE
rhel: update version code for the dev_err_probe() if guard

### DIFF
--- a/drivers/net/phy/qsfp-mem-dfl.c
+++ b/drivers/net/phy/qsfp-mem-dfl.c
@@ -29,7 +29,7 @@ static int qsfp_dfl_probe(struct dfl_device *dfl_dev)
 
 	ret = qsfp_init_work(qsfp);
 	if (ret) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x803
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
 		dev_err(dev,
 #else
 		dev_err_probe(dev, ret,

--- a/drivers/net/phy/qsfp-mem-platform.c
+++ b/drivers/net/phy/qsfp-mem-platform.c
@@ -53,7 +53,7 @@ static int qsfp_platform_probe(struct platform_device *pdev)
 
 	ret = qsfp_init_work(qsfp);
 	if (ret) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x803
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
 		dev_err(dev,
 #else
 		dev_err_probe(dev, ret,


### PR DESCRIPTION
Update the RHEL version code since dev_err_probe() has not been backported to RHEL 8.3.

Signed-off-by: Marco Pagani <marpagan@redhat.com>