### PR TITLE
fpga: bridge: properly initialize bridge device before populating chi…

### DIFF
--- a/drivers/fpga/fpga-bridge.c
+++ b/drivers/fpga/fpga-bridge.c
@@ -360,7 +360,6 @@ fpga_bridge_register(struct device *parent, const char *name,
 	bridge->dev.parent = parent;
 	bridge->dev.of_node = parent->of_node;
 	bridge->dev.id = id;
-	of_platform_populate(bridge->dev.of_node, NULL, NULL, &bridge->dev);
 
 	ret = dev_set_name(&bridge->dev, "br%d", id);
 	if (ret)
@@ -371,6 +370,8 @@ fpga_bridge_register(struct device *parent, const char *name,
 		put_device(&bridge->dev);
 		return ERR_PTR(ret);
 	}
+
+	of_platform_populate(bridge->dev.of_node, NULL, NULL, &bridge->dev);
 
 	return bridge;
 


### PR DESCRIPTION
…ldren

commit dc70eb868b9cd2ca01313e5a394e6ea001d513e9 upstream.

The current code path can lead to warnings because of uninitialized device, which contains, as a consequence, uninitialized kobject. The uninitialized device is passed to of_platform_populate, which will at some point, while creating child device, try to get a reference on uninitialized parent, resulting in the following warning:

kobject: '(null)' ((ptrval)): is not initialized, yet kobject_get() is being called.

The warning is observed after migrating a kernel 5.10.x to 6.1.x. Reverting commit 0d70af3c2530 ("fpga: bridge: Use standard dev_release for class driver") seems to remove the warning.
This commit aggregates device_initialize() and device_add() into device_register() but this new call is done AFTER of_platform_populate

Fixes: 0d70af3c2530 ("fpga: bridge: Use standard dev_release for class driver")

Acked-by: Xu Yilun <yilun.xu@intel.com>
Link: https://lore.kernel.org/r/20230404133102.2837535-2-alexis.lothore@bootlin.com