### PR TITLE
Rhweight/backport/param size zero

### DIFF
--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -1203,6 +1203,21 @@ static int dfh_get_param_size(void __iomem *dfh_base, resource_size_t max)
 	return -ENOENT;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
+static void unrolled_memcpy_fromio(void *to, const volatile void __iomem *from, size_t n)
+{
+	const volatile char __iomem *in = from;
+	u64 *out = to;
+	int i;
+
+	for (i = 0; i < n; i += 8)
+		out[i] = readq(&in[i]);
+}
+
+#undef memcpy_fromio
+#define memcpy_fromio	unrolled_memcpy_fromio
+#endif
+
 /*
  * when create sub feature instances, for private features, it doesn't need
  * to provide resource size and feature id as they could be read from DFH


### PR DESCRIPTION
Two fixes to support older AC ADP images and to support older kernels:

(1) Use an alternate implementation for memcpy_fromio() for older kernels to avoid performance issues
(2) For older AC ADP images, accept a zero parameter size as an end-of-list marker