### PR TITLE
Build and packaging fixes

### DIFF
--- a/build/debian/rules
+++ b/build/debian/rules
@@ -15,7 +15,6 @@ install: build
 	cp -a ../LICENSE $(CURDIR)/debian/tmp/usr/src/intel-fpga-dfl-$(PKGVER)/
 	cp -a dkms/dkms-postinst.sh $(CURDIR)/debian/tmp/usr/src/intel-fpga-dfl-$(PKGVER)/
 	cp -a dkms/dkms-postrem.sh $(CURDIR)/debian/tmp/usr/src/intel-fpga-dfl-$(PKGVER)/
-	cp -a dkms/dkms-preinst.sh $(CURDIR)/debian/tmp/usr/src/intel-fpga-dfl-$(PKGVER)/
 	cp -a dkms/generate-dkms-conf.sh $(CURDIR)/debian/tmp/usr/src/intel-fpga-dfl-$(PKGVER)/
 	sed -e 's/PKGVER/$(PKGVER)/' dkms/dkms.conf.in > $(CURDIR)/debian/tmp/usr/src/intel-fpga-dfl-$(PKGVER)/dkms.conf
 	sed -e 's/PKGVER/$(PKGVER)/' debian/intel-fpga-dfl-dkms.postinst.in >$(CURDIR)/debian/intel-fpga-dfl-dkms.postinst

--- a/build/dkms/dkms-postinst.sh
+++ b/build/dkms/dkms-postinst.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 # Copyright(c) 2022, Intel Corporation
 depmod -A
-modprobe dfl_pci
+if egrep --quiet '^dfl_pci ' /proc/modules; then
+	echo
+	echo   '*** Another version of the driver is already loaded. Please'
+	echo   '*** reboot your machine to activate the newly installed driver.'
+	echo
+else
+	modprobe dfl_pci
+fi

--- a/build/dkms/dkms-preinst.sh
+++ b/build/dkms/dkms-preinst.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Copyright(c) 2022, Intel Corporation
-make rmmod

--- a/build/dkms/dkms.conf.in
+++ b/build/dkms/dkms.conf.in
@@ -9,7 +9,6 @@ DEST_MODULE_LOCATION="/kernel"
 
 POST_INSTALL=dkms-postinst.sh
 POST_REMOVE=dkms-postrem.sh
-PRE_INSTALL=dkms-preinst.sh
 
 local dkms_dir="$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION"
 local dkms_generated_conf="$dkms_dir/dkms-$kernelver-$arch.conf"

--- a/build/rpm/intel-fpga-dfl.spec
+++ b/build/rpm/intel-fpga-dfl.spec
@@ -20,7 +20,7 @@ https://github.com/OPAE/linux-dfl/.
 install -d %{_pkgdir}
 cp -a LICENSE Makefile drivers include %{_pkgdir}
 cp -a build/dkms/dkms-postinst.sh build/dkms/dkms-postrem.sh %{_pkgdir}
-cp -a build/dkms/dkms-preinst.sh build/dkms/generate-dkms-conf.sh %{_pkgdir}
+cp -a build/dkms/generate-dkms-conf.sh %{_pkgdir}
 sed -E 's/PKGVER/%{version}-%{release}/' build/dkms/dkms.conf.in > %{_pkgdir}/dkms.conf
 install -d $(dirname %{buildroot}%{_dracut})
 echo 'omit_drivers+="%_modules"' > %{buildroot}%{_dracut}

--- a/build/rpm/intel-fpga-dfl.spec
+++ b/build/rpm/intel-fpga-dfl.spec
@@ -23,7 +23,7 @@ cp -a build/dkms/dkms-postinst.sh build/dkms/dkms-postrem.sh %{_pkgdir}
 cp -a build/dkms/generate-dkms-conf.sh %{_pkgdir}
 sed -E 's/PKGVER/%{version}-%{release}/' build/dkms/dkms.conf.in > %{_pkgdir}/dkms.conf
 install -d $(dirname %{buildroot}%{_dracut})
-echo 'omit_drivers+="%_modules"' > %{buildroot}%{_dracut}
+echo 'omit_drivers+=" %_modules "' > %{buildroot}%{_dracut}
 
 %post
 dkms add intel-fpga-dfl/%{version}-%{release} --rpm_safe_upgrade

--- a/include/linux/version.h
+++ b/include/linux/version.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __BACKPORT_VERSION_H
+#define __BACKPORT_VERSION_H
+
+#include_next <linux/version.h>
+
+#if !defined(RHEL_RELEASE_CODE)
+#define RHEL_RELEASE_CODE 0
+#endif
+
+#endif


### PR DESCRIPTION
There are three commits in this PR. They are all build/packaging related, but they are also independent of each other. There is too much in the commit messages to repeat it all here. Please take a look at each of the commit messages as part of the review.

In summary, the changes are:
(1) RPM spec file was creating a dracut configuration file with a syntax error - this is fixed
(2) Silence RHEL_RELEASE_CODE warnings when compiling against a non-RedHat kernel
(3) Handle installing the driver package on top of a kernel that already has the dfl modules loaded in the kernel
