### PR TITLE
backport: Avoid function name conflict in rhel8.8

### DIFF
--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -1214,18 +1214,16 @@ static int dfh_get_param_size(void __iomem *dfh_base, resource_size_t max)
 }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
-static void unrolled_memcpy_fromio(void *to, const volatile void __iomem *from, size_t n)
+static void backport_memcpy_fromio(u64 *to, const volatile void __iomem *from, size_t n)
 {
-	const volatile char __iomem *in = from;
-	u64 *out = to;
-	int i;
+	size_t i;
 
-	for (i = 0; i < n; i += 8)
-		out[i] = readq(&in[i]);
+	for (i = 0; i < n; i += sizeof(u64))
+		*to++ = readq(from + i);
 }
 
 #undef memcpy_fromio
-#define memcpy_fromio	unrolled_memcpy_fromio
+#define memcpy_fromio backport_memcpy_fromio
 #endif
 
 /*


### PR DESCRIPTION
Fix a name conflict for RHEL 8.8 that was introduced by:

64772ab52f7e backport: Avoid memcpy_fromio() issues on older kernels

The above patch added a new function, unrolled_memcpy_fromio(), to be used to avoid performance issues with older kernels. Unfortunately, this same function name is also present in RHEL 8.8 with a different definition. Rename the function to backport_memcpy_fromio() to avoid the conflict.

The backport_memcpy_fromio() function definition is also simplified.