### PR TITLE
uio: dfl: add MODULE_ALIAS for all type/id pairs

### DIFF
--- a/drivers/uio/uio_dfl.c
+++ b/drivers/uio/uio_dfl.c
@@ -190,5 +190,8 @@ module_dfl_driver(uio_dfl_driver);
 
 MODULE_DESCRIPTION("Generic DFL driver for Userspace I/O devices");
 MODULE_ALIAS("dfl:t0000f0015");
+MODULE_ALIAS("dfl:t0000f0020");
+MODULE_ALIAS("dfl:t0000f0023");
+MODULE_ALIAS("dfl:t0001f0014");
 MODULE_AUTHOR("Intel Corporation");
 MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
For the out of tree driver, one needs to add a MODULE_ALIAS for each feature type/id pair for the module to properly autoload.