### PR TITLE
uio: dfl: add MODULE_ALIAS for FME_FEATURE_ID_ETH_GROUP

### DIFF
--- a/drivers/uio/uio_dfl.c
+++ b/drivers/uio/uio_dfl.c
@@ -189,6 +189,7 @@ static struct dfl_driver uio_dfl_driver = {
 module_dfl_driver(uio_dfl_driver);
 
 MODULE_DESCRIPTION("Generic DFL driver for Userspace I/O devices");
+MODULE_ALIAS("dfl:t0000f0010");
 MODULE_ALIAS("dfl:t0000f0015");
 MODULE_ALIAS("dfl:t0000f0020");
 MODULE_ALIAS("dfl:t0000f0023");


### PR DESCRIPTION
Add a MODULE_ALIAS for FME_FEATURE_ID_ETH_GROUP so that the out of tree driver will autoload properly.

Signed-off-by: Matthew Gerlach <matthew.gerlach@linux.intel.com