### PR TITLE
.github: workflows: trigger on pushing tag

### DIFF
--- a/.github/workflows/dkms.yml
+++ b/.github/workflows/dkms.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - 'intel/**'
       - 'intel-test/**'
+    tags:
+      - 'intel-*'
     paths:
       - '.github/workflows/dkms.yml'
       - 'Makefile'

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - 'intel/**'
       - 'intel-test/**'
+    tags:
+      - 'intel-*'
     paths:
       - '.github/workflows/modules.yml'
       - 'Makefile'


### PR DESCRIPTION
This builds dkms packages including the correct version for future tags.