### PR TITLE
container: build Rocky Linux 8.4 container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -32,6 +32,9 @@ jobs:
             tag: 8
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel
+            tag: 8.4
+          - image: rockylinux-kernel-devel
+            container: rockylinux-8-kernel-devel
             tag: 8.6
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel

--- a/container/rockylinux-8-kernel-devel/Dockerfile
+++ b/container/rockylinux-8-kernel-devel/Dockerfile
@@ -1,5 +1,8 @@
 ARG tag=8
-FROM rockylinux:${tag}
+# Pull non-official image to retrieve archived versions that were
+# removed from the official library, such as rockylinux:8.4.
+# https://forums.rockylinux.org/t/rockylinux-8-4-not-in-official-rockylinux-docker-images-tag-list/5248
+FROM rockylinux/rockylinux:${tag}
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG tag
 # The PowerTools repository is needed for dwarves, which is a


### PR DESCRIPTION
This reproduces a build failure with older RHEL 8 kernels.

Link: https://github.com/OFS/linux-dfl-backport/pull/93#issuecomment-1846101410