### PR TITLE
.github: workflows: build modules on Rocky Linux 8.4, 8.6, and 8.8

### DIFF
--- a/.github/workflows/dkms.yml
+++ b/.github/workflows/dkms.yml
@@ -34,13 +34,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: rockylinux-8
+          - vendor: rockylinux
+            release: 8
             pkg: rpm
-          - os: ubuntu-22.04
+          - vendor: ubuntu
+            release: 22.04
             pkg: deb
 
     container:
-      image: ghcr.io/ofs/linux-dfl-backport/${{ matrix.os }}-kernel-devel
+      image: ghcr.io/ofs/linux-dfl-backport/${{ matrix.vendor }}-kernel-devel:${{ matrix.release }}
 
     steps:
     - name: Checkout repository
@@ -68,6 +70,6 @@ jobs:
     - name: Upload dkms package
       uses: actions/upload-artifact@v3
       with:
-        name: linux-dfl-backport-dkms-${{ matrix.os }}-${{ github.run_id }}
+        name: linux-dfl-backport-dkms-${{ matrix.vendor }}-${{ matrix.release }}-${{ github.run_id }}
         path: '*.${{ matrix.pkg }}'
         if-no-files-found: error

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -33,12 +33,25 @@ jobs:
 
     strategy:
       matrix:
-        os:
-          - rockylinux-8
-          - ubuntu-22.04
+        include:
+          - vendor: rockylinux
+            release: 8
+            pkg: rpm
+          - vendor: rockylinux
+            release: 8.4
+            pkg: rpm
+          - vendor: rockylinux
+            release: 8.6
+            pkg: rpm
+          - vendor: rockylinux
+            release: 8.8
+            pkg: rpm
+          - vendor: ubuntu
+            release: 22.04
+            pkg: deb
 
     container:
-      image: ghcr.io/ofs/linux-dfl-backport/${{ matrix.os }}-kernel-devel
+      image: ghcr.io/ofs/linux-dfl-backport/${{ matrix.vendor }}-kernel-devel:${{ matrix.release }}
 
     steps:
     - name: Checkout repository
@@ -65,6 +78,6 @@ jobs:
     - name: Upload modules
       uses: actions/upload-artifact@v3
       with:
-        name: linux-dfl-backport-modules-${{ matrix.os }}-${{ github.run_id }}
+        name: linux-dfl-backport-modules-${{ matrix.vendor }}-${{ matrix.release }}-${{ github.run_id }}
         path: /lib/modules/*/extra/
         if-no-files-found: error


### PR DESCRIPTION
Test on previous minor releases to ensure appropriate #ifdef when using kernel interfaces that were backported in a RHEL minor release. This follows commits 34475d4fa0a2 ("container: support parametrising distribution release version"), 72bb68b8279d ("container: build Rocky Linux 8.6 and 8.8 containers") and 5cb0c16533b1 ("container: build Rocky Linux 8.4 container").

Link: https://github.com/OFS/linux-dfl-backport/pull/93