### PR TITLE
fpga: dfl: Fix the dfl dev type to Private Feature

### DIFF
--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -69,7 +69,7 @@ static struct dfl_dev_info dfl_devs[] = {
 	{.name = DFL_FPGA_FEATURE_DEV_PORT, .dfh_id = DFH_ID_FIU_PORT,
 	 .devt_type = DFL_FPGA_DEVT_PORT},
 	{.name = DFL_FPGA_FEATURE_DEV_PRIV_FEAT, .dfh_id = DFH_ID_FIU_PRIV_FEAT,
-	 .devt_type = DFL_FPGA_DEVT_PORT},
+	 .devt_type = DFL_FPGA_DEVT_PRIV_FEAT},
 };
 
 /**


### PR DESCRIPTION
The device type was set to Port Type and changed to Private to reflect the correct device type.

Signed-off-by: Basheer Ahmed Muddebihal <basheer.ahmed.muddebihal@linux.intel.com>
(cherry picked from commit 80e6f5a394c88545ececcb7dda4e926e8b5de10c)