### PR TITLE
Rchriste/backport dfl cxl cache ao

### DIFF
--- a/drivers/fpga/dfl-dma-cxl-common.h
+++ b/drivers/fpga/dfl-dma-cxl-common.h
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (C) 2024 Intel Corporation
+ *
+ * This file contains code shared between dfl-afu-dma-region.c and dfl-cxl-cache.c
+ */
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0) && RHEL_RELEASE_CODE < 0x803
+static long afu_dma_adjust_locked_vm(struct device *dev, long npages, bool incr)
+{
+	unsigned long locked, lock_limit;
+	int ret = 0;
+
+	/* the task is exiting. */
+	if (!current->mm)
+		return 0;
+
+	down_write(&current->mm->mmap_sem);
+
+	if (incr) {
+		locked = current->mm->locked_vm + npages;
+		lock_limit = rlimit(RLIMIT_MEMLOCK) >> PAGE_SHIFT;
+
+		if (locked > lock_limit && !capable(CAP_IPC_LOCK))
+			ret = -ENOMEM;
+		else
+			current->mm->locked_vm += npages;
+	} else {
+
+		if (WARN_ON_ONCE(npages > current->mm->locked_vm))
+			npages = current->mm->locked_vm;
+		current->mm->locked_vm -= npages;
+	}
+
+	dev_dbg(dev, "[%d] RLIMIT_MEMLOCK %c%ld %ld/%ld%s\n", current->pid,
+				incr ? '+' : '-',
+				npages << PAGE_SHIFT,
+				current->mm->locked_vm << PAGE_SHIFT,
+				rlimit(RLIMIT_MEMLOCK),
+				ret ? "- execeeded" : "");
+
+	up_write(&current->mm->mmap_sem);
+
+	return ret;
+}
+#endif

--- a/drivers/net/phy/qsfp-mem-dfl.c
+++ b/drivers/net/phy/qsfp-mem-dfl.c
@@ -29,12 +29,7 @@ static int qsfp_dfl_probe(struct dfl_device *dfl_dev)
 
 	ret = qsfp_init_work(qsfp);
 	if (ret) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
-		dev_err(dev,
-#else
-		dev_err_probe(dev, ret,
-#endif
-			      "Failed to initialize delayed work to read QSFP\n");
+		dev_err_probe(dev, ret, "Failed to initialize delayed work to read QSFP\n");
 		goto exit;
 	}
 

--- a/drivers/net/phy/qsfp-mem-platform.c
+++ b/drivers/net/phy/qsfp-mem-platform.c
@@ -53,12 +53,7 @@ static int qsfp_platform_probe(struct platform_device *pdev)
 
 	ret = qsfp_init_work(qsfp);
 	if (ret) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
-		dev_err(dev,
-#else
-		dev_err_probe(dev, ret,
-#endif
-			      "Failed to initialize delayed work to read QSFP\n");
+		dev_err_probe(dev, ret, "Failed to initialize delayed work to read QSFP\n");
 		goto exit;
 	}
 

--- a/drivers/ptp/ptp_dfl_tod.c
+++ b/drivers/ptp/ptp_dfl_tod.c
@@ -247,7 +247,7 @@ static int dfl_tod_get_timex(struct ptp_clock_info *ptp, struct timespec64 *ts,
 	ts->tv_sec = seconds;
 #else
 	ts->tv_sec = (__kernel_time_t)seconds;
-#endif        
+#endif
 
 	return 0;
 }
@@ -302,12 +302,7 @@ static int dfl_tod_probe(struct dfl_device *ddev)
 
 	dt->ptp_clock = ptp_clock_register(&dt->ptp_clock_ops, dev);
 	if (IS_ERR(dt->ptp_clock)) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
-		dev_err(dev,
-#else
-		dev_err_probe(dt->dev, PTR_ERR(dt->ptp_clock),
-#endif
-				     "Unable to register PTP clock\n");
+		dev_err_probe(dt->dev, PTR_ERR(dt->ptp_clock), "Unable to register PTP clock\n");
 	}
 
 	return 0;

--- a/drivers/tty/serial/8250/8250_dfl.c
+++ b/drivers/tty/serial/8250/8250_dfl.c
@@ -58,24 +58,14 @@ static int dfl_uart_get_params(struct dfl_device *dfl_dev, struct uart_8250_port
 
 	ret = dfh_get_u64_param_val(dfl_dev, DFHv1_PARAM_ID_CLK_FRQ, &clk_freq);
 	if (ret) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
-		dev_err(dev, "missing CLK_FRQ param\n");
-		return ret;
-#else
 		return dev_err_probe(dev, ret, "missing CLK_FRQ param\n");
-#endif
 	}
 
 	uart->port.uartclk = clk_freq;
 
 	ret = dfh_get_u64_param_val(dfl_dev, DFHv1_PARAM_ID_FIFO_LEN, &fifo_len);
 	if (ret) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
-		dev_err(dev, "missing FIFO_LEN param\n");
-		return ret;
-#else
 		return dev_err_probe(dev, ret, "missing FIFO_LEN param\n");
-#endif
   	}
 
 	switch (fifo_len) {
@@ -92,22 +82,12 @@ static int dfl_uart_get_params(struct dfl_device *dfl_dev, struct uart_8250_port
 		break;
 
 	default:
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
-		dev_err(dev, "unsupported FIFO_LEN %llu\n", fifo_len);
-		return -EINVAL;
-#else
 		return dev_err_probe(dev, -EINVAL, "unsupported FIFO_LEN %llu\n", fifo_len);
-#endif
 	}
 
 	ret = dfh_get_u64_param_val(dfl_dev, DFHv1_PARAM_ID_REG_LAYOUT, &reg_layout);
 	if (ret) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
-		dev_err(dev, "missing REG_LAYOUT param\n");
-		return ret;
-#else
 		return dev_err_probe(dev, ret, "missing REG_LAYOUT param\n");
-#endif
 	}
 
 	uart->port.regshift = FIELD_GET(DFHv1_PARAM_REG_LAYOUT_SHIFT, reg_layout);
@@ -122,12 +102,7 @@ static int dfl_uart_get_params(struct dfl_device *dfl_dev, struct uart_8250_port
 		break;
 
 	default:
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
-		dev_err(dev, "unsupported reg-width %u\n", reg_width);
-		return -EINVAL;
-#else
 		return dev_err_probe(dev, -EINVAL, "unsupported reg-width %u\n", reg_width);
-#endif
 	}
 
 	return 0;
@@ -146,12 +121,7 @@ static int dfl_uart_probe(struct dfl_device *dfl_dev)
 
 	ret = dfl_uart_get_params(dfl_dev, &uart);
 	if (ret < 0) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
-		dev_err(dev, "failed uart feature walk\n");
-		return ret;
-#else
 		return dev_err_probe(dev, ret, "failed uart feature walk\n");
-#endif
 	}
 
 	if (dfl_dev->num_irqs == 1)
@@ -163,12 +133,7 @@ static int dfl_uart_probe(struct dfl_device *dfl_dev)
 
 	dfluart->line = serial8250_register_8250_port(&uart);
 	if (dfluart->line < 0) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0) && RHEL_RELEASE_CODE < 0x804
-		dev_err(dev, "unable to register 8250 port.\n");
-		return dfluart->line;
-#else
 		return dev_err_probe(dev, dfluart->line, "unable to register 8250 port.\n");
-#endif
 	}
 
 	dev_set_drvdata(dev, dfluart);

--- a/include/linux/device.h
+++ b/include/linux/device.h
@@ -25,4 +25,29 @@ class_find_device_by_of_node(struct class *class, const struct device_node *np)
 }
 #endif /* < KERNEL_VERSION(5, 4, 0) */
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 253) || \
+(LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0))) && RHEL_RELEASE_CODE < 0x804
+/**
+ * Simplified version of upstream dev_err_probe.
+ */
+static inline int dev_err_probe(const struct device *dev, int err, const char *fmt, ...)
+{
+	struct va_format vaf;
+	va_list args;
+
+	va_start(args, fmt);
+	vaf.fmt = fmt;
+	vaf.va = &args;
+
+	if (err != -EPROBE_DEFER)
+		dev_err(dev, "error %pe: %pV", ERR_PTR(err), &vaf);
+	else
+		dev_dbg(dev, "error %pe: %pV", ERR_PTR(err), &vaf);
+
+	va_end(args);
+
+	return err;
+}
+#endif
+
 #endif


### PR DESCRIPTION
The previously added files dfl-cxl-cache.c, dfl-priv-feat-main.c, and dfl-platform.c does not compile on CentOS 8.2 (kernel 4.18.0-193.el8.x86_64) and CentOS 8.3 (kernel 4.18.0-240.22.1.el8_3.x86_64).

These files are backported.

Also backport of dev_err_probe() is simplified.