### PR TITLE
.github: workflows: build modules on CentOS 8.2 and 8.3

### DIFF
--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -34,6 +34,12 @@ jobs:
     strategy:
       matrix:
         include:
+          - vendor: centos
+            release: '8.2.2004'
+            pkg: rpm
+          - vendor: centos
+            release: '8.3.2011'
+            pkg: rpm
           - vendor: rockylinux
             release: '8'
             pkg: rpm


### PR DESCRIPTION
Build with RHEL kernels 4.18.0-193.28.1.el8_2 and 4.18.0-240.22.1.el8_3.