### PR TITLE
net: phy: qsfp-mem-platform: replace of_device.h with explicit includes

### DIFF
--- a/drivers/net/phy/qsfp-mem-platform.c
+++ b/drivers/net/phy/qsfp-mem-platform.c
@@ -8,8 +8,8 @@
 #include <linux/bitfield.h>
 #include <linux/module.h>
 #include <linux/of_address.h>
-#include <linux/of_device.h>
 #include <linux/phy/qsfp-mem.h>
+#include <linux/platform_device.h>
 #include <linux/processor.h>
 #include <linux/slab.h>
 


### PR DESCRIPTION
This follows commit ef175b29a242 ("of: Stop circularly including of_device.h and of_platform.h") in Linux 6.8.