### PR TITLE
Makefile: insmod: fix 'Unknown symbol in module'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,9 @@ $(rules_rmmod): rmmod_%:
 
 $(rules_insmod): insmod_%:
 	@if ! lsmod | grep -q $* && test -f $*.ko; then \
+		[ -n "${CONFIG_REGMAP_SPI_AVMM}" ] && [ $* = intel-m10-bmc-spi ] && modprobe regmap-spi-avmm; \
+		[ $* = n5010-phy ] && modprobe fixed-phy; \
+		[ $* = ptp_dfl_tod ] && modprobe ptp; \
 		[ $* = uio-dfl ] && modprobe uio; \
 		insmod $*.ko $(DYNDBG); \
 	fi


### PR DESCRIPTION
In systems where `CONFIG_REGMAP_SPI_AVMM` is defined we should ensure that *regmap-spi-avmm* is probed prior to inserting *intel-m10-bmc-spi*  
Output of **make insmod** without the fix (Ubuntu 22.04):
```bash
$ make insmod
insmod: ERROR: could not insert module intel-m10-bmc-spi.ko: Unknown symbol in module
make: *** [Makefile:178: insmod_intel-m10-bmc-spi] Error 1

$ dmesg | tail -1
[ 1277.598993] intel_m10_bmc_spi: Unknown symbol __devm_regmap_init_spi_avmm (err -2)
```

Similarly, *ptp_dfl_tod* depends on *ptp* and *n5010-phy* depends on *fixed-phy*.  
We should ensure that *fixed-phy* and *ptp* are already probed.  
Example output of **make insmod** without the fix (Debian 11):
```bash
$ make insmod
insmod: ERROR: could not insert module ptp_dfl_tod.ko: Unknown symbol in module
make: *** [Makefile:178: insmod_ptp_dfl_tod] Error 1

$ dmesg | tail -3
[  307.530700] ptp_dfl_tod: Unknown symbol scaled_ppm_to_ppb (err -2)
[  307.533061] ptp_dfl_tod: Unknown symbol ptp_clock_register (err -2)
[  307.535357] ptp_dfl_tod: Unknown symbol ptp_clock_unregister (err -2)

# after 'modprobe ptp'

$ make insmod
insmod: ERROR: could not insert module n5010-phy.ko: Unknown symbol in module
make: *** [Makefile:178: insmod_n5010-phy] Error 1

$ dmesg | tail -7
[  378.300980] n5010_phy: Unknown symbol fixed_phy_change_carrier (err -2)
[  378.302726] n5010_phy: Unknown symbol fixed_phy_unregister (err -2)
[  378.304346] n5010_phy: Unknown symbol phy_connect_direct (err -2)
[  378.305831] n5010_phy: Unknown symbol phy_detach (err -2)
[  378.307174] n5010_phy: Unknown symbol fixed_phy_set_link_update (err -2)
[  378.308825] n5010_phy: Unknown symbol fixed_phy_register (err -2)
[  378.310314] n5010_phy: Unknown symbol phy_device_free (err -2)
```