### PR TITLE
fpga: dfl-pci-sva: fix getting pasid with Linux 6.8

### DIFF
--- a/drivers/fpga/dfl-pci-sva.c
+++ b/drivers/fpga/dfl-pci-sva.c
@@ -178,12 +178,12 @@ static long ioctl_sva_bind_dev(struct dfl_sva_dev *dev, struct iommu_sva **sva_h
 		return -EINVAL;
 
 	if (*sva_handle_p)
-		return current->mm->pasid;
+		return mm_get_enqcmd_pasid(current->mm);
 
 	handle = iommu_sva_bind_device(&dev->pdev->dev, current->mm);
 	pci_info(dev->pdev, "%s: pid %d, bind sva_handle %p, pasid = %d\n",
 		 __func__, task_pid_nr(current),
-		 handle, current->mm->pasid);
+		 handle, mm_get_enqcmd_pasid(current->mm));
 
 	if (!handle)
 		return -ENODEV;
@@ -191,7 +191,7 @@ static long ioctl_sva_bind_dev(struct dfl_sva_dev *dev, struct iommu_sva **sva_h
 		return PTR_ERR(handle);
 
 	*sva_handle_p = handle;
-	return current->mm->pasid;
+	return mm_get_enqcmd_pasid(current->mm);
 }
 
 static long ioctl_sva_unbind_dev(struct dfl_sva_dev *dev, struct iommu_sva **sva_handle_p)

--- a/include/linux/iommu.h
+++ b/include/linux/iommu.h
@@ -21,4 +21,15 @@
 #define iommu_sva_bind_device(dev, mm) iommu_sva_bind_device(dev, mm, NULL)
 #endif
 
+/* Commit 2396046d75d3 ("iommu: Add mm_get_enqcmd_pasid() helper function")
+ * added a wrapper for pasid, which was moved to a private data structure in
+ * commit 092edaddb660 ("iommu: Support mm PASID 1:n with sva domains").
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+static inline u32 mm_get_enqcmd_pasid(struct mm_struct *mm)
+{
+	return mm->pasid;
+}
+#endif
+
 #endif /* _BACKPORT_LINUX_IOMMU_H_ */


### PR DESCRIPTION
Commit 2396046d75d3 ("iommu: Add mm_get_enqcmd_pasid() helper function") added a wrapper for pasid, which was moved to a private data structure in commit 092edaddb660 ("iommu: Support mm PASID 1:n with sva domains").