### PR TITLE
fpga: dfl-pci-sva: use iommu_sva_get_pasid() to obtain PASID

### DIFF
--- a/drivers/fpga/dfl-pci-sva.c
+++ b/drivers/fpga/dfl-pci-sva.c
@@ -177,21 +177,21 @@ static long ioctl_sva_bind_dev(struct dfl_sva_dev *dev, struct iommu_sva **sva_h
 	if (!current->mm)
 		return -EINVAL;
 
-	if (*sva_handle_p)
-		return mm_get_enqcmd_pasid(current->mm);
+	if ((handle = *sva_handle_p))
+		return iommu_sva_get_pasid(handle);
 
 	handle = iommu_sva_bind_device(&dev->pdev->dev, current->mm);
-	pci_info(dev->pdev, "%s: pid %d, bind sva_handle %p, pasid = %d\n",
-		 __func__, task_pid_nr(current),
-		 handle, mm_get_enqcmd_pasid(current->mm));
-
 	if (!handle)
 		return -ENODEV;
 	if (IS_ERR(handle))
 		return PTR_ERR(handle);
 
+	pci_info(dev->pdev, "%s: pid %d, bind sva_handle %p, pasid = %d\n",
+		 __func__, task_pid_nr(current),
+		 handle, iommu_sva_get_pasid(handle));
+
 	*sva_handle_p = handle;
-	return mm_get_enqcmd_pasid(current->mm);
+	return iommu_sva_get_pasid(handle);
 }
 
 static long ioctl_sva_unbind_dev(struct dfl_sva_dev *dev, struct iommu_sva **sva_handle_p)

--- a/include/linux/iommu.h
+++ b/include/linux/iommu.h
@@ -21,15 +21,4 @@
 #define iommu_sva_bind_device(dev, mm) iommu_sva_bind_device(dev, mm, NULL)
 #endif
 
-/* Commit 2396046d75d3 ("iommu: Add mm_get_enqcmd_pasid() helper function")
- * added a wrapper for pasid, which was moved to a private data structure in
- * commit 092edaddb660 ("iommu: Support mm PASID 1:n with sva domains").
- */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
-static inline u32 mm_get_enqcmd_pasid(struct mm_struct *mm)
-{
-	return mm->pasid;
-}
-#endif
-
 #endif /* _BACKPORT_LINUX_IOMMU_H_ */


### PR DESCRIPTION
Use wrapper function iommu_sva_get_pasid() around mm_get_enqcmd_pasid(), which was first introduced in commit 26b25a2b98e45 ("iommu: Bind process address spaces to devices") together with iommu_sva_bind_device() and hence does not require backporting to older kernels.

Link: https://github.com/OFS/linux-dfl-backport/pull/113#issuecomment-1970221321
Suggested-by: Michael Adler <michael.adler@intel.com>