### PR TITLE
Makefile: support out-of-source kernel build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@
 
 KERNEL ?= $(shell uname -r)
 KERNELDIR ?= /lib/modules/$(KERNEL)/build
+KERNELBUILDDIR ?= $(KERNELDIR)
 LINUXINCLUDE := -I$(src)/include -I$(src)/include/uapi $(LINUXINCLUDE)
 
 # make Kconfig conditionals always work
-include $(KERNELDIR)/.config
+include $(KERNELBUILDDIR)/.config
 
 ifeq ($(DEBUG),1)
 DYNDBG = dyndbg=+p


### PR DESCRIPTION
Yocto stores kernel source and build trees in separate directories, where the latter contains the .config file.

KERNELDIR and KERNELBUILDDIR correspond to the Yocto variables STAGING_KERNEL_DIR and STAGING_KERNEL_BUILDDIR, respectively.

Link: https://docs.yoctoproject.org/4.3/kernel-dev/common.html#incorporating-out-of-tree-modules
Link: https://docs.yoctoproject.org/4.3/ref-manual/variables.html#term-STAGING_KERNEL_DIR
Link: https://docs.yoctoproject.org/4.3/ref-manual/variables.html#term-STAGING_KERNEL_BUILDDIR