### PR TITLE
spi: spi-altera-dfl: switch to spi_controller_put()

### DIFF
--- a/drivers/spi/spi-altera-dfl.c
+++ b/drivers/spi/spi-altera-dfl.c
@@ -189,7 +189,7 @@ static int dfl_spi_altera_probe(struct dfl_device *dfl_dev)
 
 	return 0;
 exit:
-	spi_master_put(host);
+	spi_controller_put(host);
 	return err;
 }
 


### PR DESCRIPTION
spi_master_put() alias removed in kernel 6.9.