### PR TITLE
container: build Fedora 40 container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -84,5 +84,5 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push image to registry
-      if: github.event_name == 'push'
+      if: github.event_name != 'pull_request'
       run: docker image push "$image"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -41,7 +41,7 @@ jobs:
             tag: 22.04
 
     env:
-      image: ghcr.io/ofs/linux-dfl-backport/${{ matrix.image }}
+      image: ghcr.io/ofs/linux-dfl-backport/${{ matrix.image }}:${{ matrix.tag }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -29,22 +29,22 @@ jobs:
         include:
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel
-            tag: 8
+            tag: '8'
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel
-            tag: 8.4
+            tag: '8.4'
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel
-            tag: 8.6
+            tag: '8.6'
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel
-            tag: 8.8
+            tag: '8.8'
           - image: ubuntu-kernel-devel
             container: ubuntu-22.04-kernel-devel
-            tag: 20.04
+            tag: '20.04'
           - image: ubuntu-kernel-devel
             container: ubuntu-22.04-kernel-devel
-            tag: 22.04
+            tag: '22.04'
 
     env:
       image: ghcr.io/ofs/linux-dfl-backport/${{ matrix.image }}:${{ matrix.tag }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -33,6 +33,12 @@ jobs:
           - image: fedora-kernel-devel
             container: fedora-kernel-devel
             tag: 'rawhide'
+          - image: centos-kernel-devel
+            container: centos-8-kernel-devel
+            tag: '8.2.2004'
+          - image: centos-kernel-devel
+            container: centos-8-kernel-devel
+            tag: '8.3.2011'
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel
             tag: '8'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,6 +27,12 @@ jobs:
     strategy:
       matrix:
         include:
+          - image: fedora-kernel-devel
+            container: fedora-kernel-devel
+            tag: '39'
+          - image: fedora-kernel-devel
+            container: fedora-kernel-devel
+            tag: 'rawhide'
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel
             tag: '8'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -26,9 +26,13 @@ jobs:
 
     strategy:
       matrix:
-        image:
-          - rockylinux-8-kernel-devel
-          - ubuntu-22.04-kernel-devel
+        include:
+          - image: rockylinux-kernel-devel
+            container: rockylinux-8-kernel-devel
+            tag: 8
+          - image: ubuntu-kernel-devel
+            container: ubuntu-22.04-kernel-devel
+            tag: 22.04
 
     env:
       image: ghcr.io/ofs/linux-dfl-backport/${{ matrix.image }}
@@ -38,7 +42,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Build kernel development image
-      run: docker build -t "$image" -f container/${{ matrix.image }}/Dockerfile .
+      run: docker build --build-arg tag=${{ matrix.tag }} -t "$image" -f container/${{ matrix.container }}/Dockerfile .
 
     - name: Log in to registry
       if: github.event_name == 'push'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,51 @@
+name: Build kernel development containers
+
+permissions:
+  packages: write
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/container.yml'
+      - 'container/**'
+
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/container.yml'
+      - 'container/**'
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image:
+          - rockylinux-8-kernel-devel
+          - ubuntu-22.04-kernel-devel
+
+    env:
+      image: ghcr.io/ofs/linux-dfl-backport/${{ matrix.image }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Build kernel development image
+      run: docker build -t "$image" -f container/${{ matrix.image }}/Dockerfile .
+
+    - name: Log in to registry
+      if: github.event_name == 'push'
+      run: echo "$token" | docker login ghcr.io -u "$GITHUB_REPOSITORY_OWNER" --password-stdin
+      env:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Push image to registry
+      if: github.event_name == 'push'
+      run: docker image push "$image"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -30,6 +30,12 @@ jobs:
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel
             tag: 8
+          - image: rockylinux-kernel-devel
+            container: rockylinux-8-kernel-devel
+            tag: 8.6
+          - image: rockylinux-kernel-devel
+            container: rockylinux-8-kernel-devel
+            tag: 8.8
           - image: ubuntu-kernel-devel
             container: ubuntu-22.04-kernel-devel
             tag: 22.04

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -39,6 +39,15 @@ jobs:
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel
             tag: '8.8'
+          - image: rockylinux-kernel-devel
+            container: rockylinux-8-kernel-devel
+            tag: '9'
+          - image: rockylinux-kernel-devel
+            container: rockylinux-8-kernel-devel
+            tag: '9.0'
+          - image: rockylinux-kernel-devel
+            container: rockylinux-8-kernel-devel
+            tag: '9.2'
           - image: ubuntu-kernel-devel
             container: ubuntu-22.04-kernel-devel
             tag: '20.04'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -41,6 +41,9 @@ jobs:
             tag: 8.8
           - image: ubuntu-kernel-devel
             container: ubuntu-22.04-kernel-devel
+            tag: 20.04
+          - image: ubuntu-kernel-devel
+            container: ubuntu-22.04-kernel-devel
             tag: 22.04
 
     env:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -32,6 +32,9 @@ jobs:
             tag: 8
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel
+            tag: 8.4
+          - image: rockylinux-kernel-devel
+            container: rockylinux-8-kernel-devel
             tag: 8.6
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  container:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -32,6 +32,9 @@ jobs:
             tag: '39'
           - image: fedora-kernel-devel
             container: fedora-kernel-devel
+            tag: '40'
+          - image: fedora-kernel-devel
+            container: fedora-kernel-devel
             tag: 'rawhide'
           - image: centos-kernel-devel
             container: centos-8-kernel-devel

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,14 +6,14 @@ permissions:
 on:
   push:
     branches:
-      - 'main'
+      - 'intel/**'
     paths:
       - '.github/workflows/container.yml'
       - 'container/**'
 
   pull_request:
     branches:
-      - 'main'
+      - 'intel/**'
     paths:
       - '.github/workflows/container.yml'
       - 'container/**'

--- a/.github/workflows/dkms.yml
+++ b/.github/workflows/dkms.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'intel/**'
-      - 'intel-test/**'
     tags:
       - 'intel-*'
     paths:
@@ -17,7 +16,6 @@ on:
   pull_request:
     branches:
       - 'intel/**'
-      - 'intel-test/**'
     paths:
       - '.github/workflows/dkms.yml'
       - 'Makefile'

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'intel/**'
-      - 'intel-test/**'
     tags:
       - 'intel-*'
     paths:
@@ -17,7 +16,6 @@ on:
   pull_request:
     branches:
       - 'intel/**'
-      - 'intel-test/**'
     paths:
       - '.github/workflows/modules.yml'
       - 'Makefile'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # linux-dfl-backport
 Backport version of the linux-dfl (Device Feature List) kernel driver for FPGA devices. This is an out-of-tree driver, designed to be built, packaged, and installed as a stand-alone set of driver modules.
+
+This is a community project. Individual branches may be owned/maintained by different individuals or organizations to support specific kernel versions.  For example, one branch may be designed specifically to compile against all RHEL 8 kernels, and it may also provide support for building a DKMS package that will build the binary files on the target machine when it is installed. Another branch may build for both RHEL 8 and Ubuntu 22.04.  Others maybe be intended for building binary RPMs for specific kernels.
+
+Branches are only supported by the individual owners for the purposes for which the branches were created. However, you are free to copy and modify any of the branches within the constraints of the GPL V2 license as described in the included LICENSE file.
+
+If you would like information on a particular branch, please use the github "Discussions" link to start a conversation. If you can describe your goal, others members should be able to help you determine where to start.

--- a/container/centos-8-kernel-devel/Dockerfile
+++ b/container/centos-8-kernel-devel/Dockerfile
@@ -1,0 +1,38 @@
+ARG tag=8.3.2011
+FROM centos:${tag}
+# https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG tag
+# On CentOS 8, the PowerTools repository is needed for dwarves, which
+# is a build dependency of the kernel makefile target rpm-pkg.
+# The EPEL repository is needed for dkms.
+#
+# Install packages from CentOS Vault Mirror since mirrorlist is empty.
+RUN sed -i '/^enabled=/s#0#1#' /etc/yum.repos.d/CentOS-*PowerTools.repo \
+    && sed -i -e '/^mirrorlist/s,^,#,' \
+        -e "s,^#\\?\\(baseurl=http://\\)mirror.centos.org/\$contentdir/\$releasever/,\\1/vault.centos.org/${tag}/," \
+        /etc/yum.repos.d/CentOS-*.repo \
+    && yum -y upgrade \
+    && yum -y install epel-release \
+    && yum -y install \
+    bc \
+    bison \
+    ca-certificates \
+    cpio \
+    dkms \
+    dwarves \
+    elfutils-libelf-devel \
+    flex \
+    gcc \
+    git \
+    kernel \
+    kernel-devel \
+    kernel-headers \
+    make \
+    ncurses-devel \
+    openssl-devel \
+    perl \
+    pkg-config \
+    python3 \
+    rpm-build \
+    rsync \
+    && yum -y clean all

--- a/container/fedora-kernel-devel/Dockerfile
+++ b/container/fedora-kernel-devel/Dockerfile
@@ -1,0 +1,28 @@
+ARG tag=rawhide
+FROM fedora:${tag}
+# https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG tag
+RUN yum -y upgrade \
+    && yum -y install \
+    bc \
+    bison \
+    ca-certificates \
+    cpio \
+    dkms \
+    dwarves \
+    elfutils-libelf-devel \
+    flex \
+    gcc \
+    git \
+    kernel \
+    kernel-devel \
+    kernel-headers \
+    make \
+    ncurses-devel \
+    openssl-devel \
+    perl \
+    pkg-config \
+    python3 \
+    rpm-build \
+    rsync \
+    && yum -y clean all

--- a/container/fedora-kernel-devel/Dockerfile
+++ b/container/fedora-kernel-devel/Dockerfile
@@ -2,8 +2,8 @@ ARG tag=rawhide
 FROM fedora:${tag}
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG tag
-RUN yum -y upgrade \
-    && yum -y install \
+RUN dnf -y upgrade \
+    && dnf -y install \
     bc \
     bison \
     ca-certificates \
@@ -25,4 +25,4 @@ RUN yum -y upgrade \
     python3 \
     rpm-build \
     rsync \
-    && yum -y clean all
+    && dnf -y clean all

--- a/container/rockylinux-8-kernel-devel/Dockerfile
+++ b/container/rockylinux-8-kernel-devel/Dockerfile
@@ -1,4 +1,5 @@
-FROM rockylinux:8
+ARG tag=8
+FROM rockylinux:${tag}
 # The PowerTools repository is needed for dwarves, which is a
 # build dependency of the kernel makefile target rpm-pkg.
 # The EPEL repository is needed for dkms.

--- a/container/rockylinux-8-kernel-devel/Dockerfile
+++ b/container/rockylinux-8-kernel-devel/Dockerfile
@@ -1,5 +1,8 @@
 ARG tag=8
-FROM rockylinux:${tag}
+# Pull non-official image to retrieve archived versions that were
+# removed from the official library, such as rockylinux:8.4.
+# https://forums.rockylinux.org/t/rockylinux-8-4-not-in-official-rockylinux-docker-images-tag-list/5248
+FROM rockylinux/rockylinux:${tag}
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG tag
 # The PowerTools repository is needed for dwarves, which is a

--- a/container/rockylinux-8-kernel-devel/Dockerfile
+++ b/container/rockylinux-8-kernel-devel/Dockerfile
@@ -1,10 +1,21 @@
 ARG tag=8
 FROM rockylinux:${tag}
+# https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG tag
 # The PowerTools repository is needed for dwarves, which is a
 # build dependency of the kernel makefile target rpm-pkg.
 # The EPEL repository is needed for dkms.
+#
+# When ${tag} is explicitly given as a minor version, e.g., 8.6,
+# install packages from the vault repositories instead of the default
+# mirrors. Otherwise, packages will be upgraded or installed from the
+# latest minor release, e.g., 8.6 is upgraded to 8.9 or 8.10, which
+# we want to specifically avoid, to build against older kernels.
 RUN sed -i '/^enabled=/s#0#1#' /etc/yum.repos.d/Rocky-PowerTools.repo \
     && grep '^enabled=1$' /etc/yum.repos.d/Rocky-PowerTools.repo \
+    && ([[ "${tag}" != *.* ]] || sed -i -e '/^mirrorlist/s,^,#,' \
+        -e "s,^#\\?\\(baseurl=http://dl.rockylinux.org\\)/\$contentdir/\$releasever/,\\1/vault/rocky/${tag}/," \
+        /etc/yum.repos.d/Rocky-*.repo) \
     && yum -y upgrade \
     && yum -y install epel-release \
     && yum -y install \

--- a/container/rockylinux-8-kernel-devel/Dockerfile
+++ b/container/rockylinux-8-kernel-devel/Dockerfile
@@ -1,0 +1,31 @@
+FROM rockylinux:8
+# The PowerTools repository is needed for dwarves, which is a
+# build dependency of the kernel makefile target rpm-pkg.
+# The EPEL repository is needed for dkms.
+RUN sed -i '/^enabled=/s#0#1#' /etc/yum.repos.d/Rocky-PowerTools.repo \
+    && grep '^enabled=1$' /etc/yum.repos.d/Rocky-PowerTools.repo \
+    && yum -y upgrade \
+    && yum -y install epel-release \
+    && yum -y install \
+    bc \
+    bison \
+    ca-certificates \
+    cpio \
+    dkms \
+    dwarves \
+    elfutils-libelf-devel \
+    flex \
+    gcc \
+    git \
+    kernel \
+    kernel-devel \
+    kernel-headers \
+    make \
+    ncurses-devel \
+    openssl-devel \
+    perl \
+    pkg-config \
+    python3 \
+    rpm-build \
+    rsync \
+    && yum -y clean all

--- a/container/rockylinux-8-kernel-devel/Dockerfile
+++ b/container/rockylinux-8-kernel-devel/Dockerfile
@@ -5,8 +5,8 @@ ARG tag=8
 FROM rockylinux/rockylinux:${tag}
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG tag
-# The PowerTools repository is needed for dwarves, which is a
-# build dependency of the kernel makefile target rpm-pkg.
+# On Rocky 8, the PowerTools repository is needed for dwarves, which
+# is a build dependency of the kernel makefile target rpm-pkg.
 # The EPEL repository is needed for dkms.
 #
 # When ${tag} is explicitly given as a minor version, e.g., 8.6,
@@ -14,11 +14,11 @@ ARG tag
 # mirrors. Otherwise, packages will be upgraded or installed from the
 # latest minor release, e.g., 8.6 is upgraded to 8.9 or 8.10, which
 # we want to specifically avoid, to build against older kernels.
-RUN sed -i '/^enabled=/s#0#1#' /etc/yum.repos.d/Rocky-PowerTools.repo \
-    && grep '^enabled=1$' /etc/yum.repos.d/Rocky-PowerTools.repo \
+RUN ([[ "${tag}" != 8* ]] || sed -i '/^enabled=/s#0#1#' \
+        /etc/yum.repos.d/Rocky-PowerTools.repo) \
     && ([[ "${tag}" != *.* ]] || sed -i -e '/^mirrorlist/s,^,#,' \
         -e "s,^#\\?\\(baseurl=http://dl.rockylinux.org\\)/\$contentdir/\$releasever/,\\1/vault/rocky/${tag}/," \
-        /etc/yum.repos.d/Rocky-*.repo) \
+        /etc/yum.repos.d/[Rr]ocky*.repo) \
     && yum -y upgrade \
     && yum -y install epel-release \
     && yum -y install \

--- a/container/rockylinux-8-kernel-devel/Dockerfile
+++ b/container/rockylinux-8-kernel-devel/Dockerfile
@@ -19,9 +19,9 @@ RUN ([[ "${tag}" != 8* ]] || sed -i '/^enabled=/s#0#1#' \
     && ([[ "${tag}" != *.* ]] || sed -i -e '/^mirrorlist/s,^,#,' \
         -e "s,^#\\?\\(baseurl=http://dl.rockylinux.org\\)/\$contentdir/\$releasever/,\\1/vault/rocky/${tag}/," \
         /etc/yum.repos.d/[Rr]ocky*.repo) \
-    && yum -y upgrade \
-    && yum -y install epel-release \
-    && yum -y install \
+    && dnf -y upgrade \
+    && dnf -y install epel-release \
+    && dnf -y install \
     bc \
     bison \
     ca-certificates \
@@ -43,4 +43,4 @@ RUN ([[ "${tag}" != 8* ]] || sed -i '/^enabled=/s#0#1#' \
     python3 \
     rpm-build \
     rsync \
-    && yum -y clean all
+    && dnf -y clean all

--- a/container/ubuntu-22.04-kernel-devel/Dockerfile
+++ b/container/ubuntu-22.04-kernel-devel/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -qq update \
     libelf-dev \
     libncurses-dev \
     libssl-dev \
+    linux-image-generic \
     linux-headers-generic \
     openssl \
     pkg-config \

--- a/container/ubuntu-22.04-kernel-devel/Dockerfile
+++ b/container/ubuntu-22.04-kernel-devel/Dockerfile
@@ -1,7 +1,7 @@
 ARG tag=22.04
 FROM ubuntu:${tag}
 RUN apt-get -qq update \
-    && apt-get -qq upgrade --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade --no-install-recommends \
     bc \
     bison \
     build-essential \

--- a/container/ubuntu-22.04-kernel-devel/Dockerfile
+++ b/container/ubuntu-22.04-kernel-devel/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:22.04
+ARG tag=22.04
+FROM ubuntu:${tag}
 RUN apt-get -qq update \
     && apt-get -qq upgrade --no-install-recommends \
     bc \

--- a/container/ubuntu-22.04-kernel-devel/Dockerfile
+++ b/container/ubuntu-22.04-kernel-devel/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:22.04
+RUN apt-get -qq update \
+    && apt-get -qq upgrade --no-install-recommends \
+    bc \
+    bison \
+    build-essential \
+    ca-certificates \
+    cpio \
+    debhelper \
+    devscripts \
+    dkms \
+    flex \
+    git \
+    kmod \
+    libelf-dev \
+    libncurses-dev \
+    libssl-dev \
+    linux-headers-generic \
+    openssl \
+    pkg-config \
+    python3 \
+    rsync \
+    wget \
+    zstd \
+    && apt-get clean


### PR DESCRIPTION
This cherry-picks all but the initial commit 21b4bfee170e8ada76cd72f2adbdc3220c2263a9 from the `main` branch, in preparation of setting `intel/fpga-ofs-dev-6.6-lts` as the default branch of the repository. The Linux DFL backport driver is the officially supported distribution method for the latest DFL kernel modules starting with OFS 2024.2.