### PR TITLE
.github: workflows: resolve deprecation warnings about Node.js 16 actions

### DIFF
--- a/.github/workflows/dkms.yml
+++ b/.github/workflows/dkms.yml
@@ -66,7 +66,7 @@ jobs:
       run: make ${{ matrix.pkg }} KERNEL="$(basename /lib/modules/*)"
 
     - name: Upload dkms package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-dfl-backport-dkms-${{ matrix.vendor }}-${{ matrix.release }}-${{ github.run_id }}
         path: '*.${{ matrix.pkg }}'

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -101,7 +101,7 @@ jobs:
       run: make KERNEL="$(basename /lib/modules/*)" install
 
     - name: Upload modules
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-dfl-backport-modules-${{ matrix.vendor }}-${{ matrix.release }}-${{ github.run_id }}
         path: /lib/modules/*/extra/


### PR DESCRIPTION
Link: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/