### PR TITLE
.github: workflows: do not cancel matrix jobs if any job fails

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - image: fedora-kernel-devel

--- a/.github/workflows/dkms.yml
+++ b/.github/workflows/dkms.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - vendor: rockylinux

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - vendor: centos


### PR DESCRIPTION
The default fail-fast strategy cancels all jobs in the matrix when any job fails, which unnecessarily complicates backporting. The matrix jobs usually all start in parallel, which means most resources for running each job, such as for pulling the container and cloning the repository, have already been consumed by the time any actual build step fails.

Link: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast