### PR TITLE
tty: serial: 8250: add GUID to hard-coded module alias in 8250_dfl driver

### DIFF
--- a/drivers/tty/serial/8250/8250_dfl.c
+++ b/drivers/tty/serial/8250/8250_dfl.c
@@ -170,7 +170,7 @@ static struct dfl_driver dfl_uart_driver = {
 };
 module_dfl_driver(dfl_uart_driver);
 
-MODULE_ALIAS("dfl:t0000f0024");
+MODULE_ALIAS("dfl:t0000f0024g{9E6641A6-CA26-CC04-E1DF-0D4ACE8E486C}");
 MODULE_DESCRIPTION("DFL Intel UART driver");
 MODULE_AUTHOR("Intel Corporation");
 MODULE_LICENSE("GPL");


### PR DESCRIPTION
The DFHv1 GUID needs to match for automatic loading of the driver.

Fixes: 0e524ef22e1b ("tty: serial: 8250: Add the GUID definition for UART")