### PR TITLE
fpga: dfl: fme: fix regression querying platform device in power_hwmon_write()

### DIFF
--- a/drivers/fpga/dfl-fme-main.c
+++ b/drivers/fpga/dfl-fme-main.c
@@ -432,7 +432,7 @@ static int power_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
 static int power_hwmon_write(struct device *dev, enum hwmon_sensor_types type,
 			     u32 attr, int channel, long val)
 {
-	struct dfl_feature_dev_data *fdata = to_dfl_feature_dev_data(dev);
+	struct dfl_feature_dev_data *fdata = to_dfl_feature_dev_data(dev->parent);
 	struct dfl_feature *feature = dev_get_drvdata(dev);
 	int ret = 0;
 	u64 v;


### PR DESCRIPTION
The function power_hwmon_write() receives a hwmon device created with devm_hwmon_device_register_with_info(). Its parent device is the platform device, i.e., dfl-fme.X device. The platform device is passed to to_dfl_feature_dev_data(), which queries the associated platform data to retrieve the feature device data.

The FME power management feature was available on Intel(R) Xeon(R) CPU with Integrated FPGAs, which were capable of drawing more power than the socket could deliver. Discrete FPGA cards do not expose this feature.

Fixes: 43adaa2e52db ("fpga: dfl: fix the kernel warning when release/assign ports for SRIOV")
Cc: @yilunxu1984 