### PR TITLE
backport: avoid duplicate definition of spi_get_chipselect() with Linux 6.3

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -64,6 +64,9 @@ jobs:
           - image: rockylinux-kernel-devel
             container: rockylinux-8-kernel-devel
             tag: '9.2'
+          - image: debian-kernel-devel
+            container: debian-12-kernel-devel
+            tag: '12'
           - image: ubuntu-kernel-devel
             container: ubuntu-22.04-kernel-devel
             tag: '20.04'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -18,6 +18,9 @@ on:
       - '.github/workflows/container.yml'
       - 'container/**'
 
+  schedule:
+    - cron: "11 18 * * 1"
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dkms.yml
+++ b/.github/workflows/dkms.yml
@@ -23,6 +23,9 @@ on:
       - 'drivers/**'
       - 'include/**'
 
+  schedule:
+    - cron: "33 18 * * 1"
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -23,6 +23,9 @@ on:
       - 'drivers/**'
       - 'include/**'
 
+  schedule:
+    - cron: "32 18 * * 1"
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -69,6 +69,9 @@ jobs:
           - vendor: rockylinux
             release: '9.2'
             pkg: rpm
+          - vendor: debian
+            release: '12'
+            pkg: deb
           - vendor: ubuntu
             release: '20.04'
             pkg: deb

--- a/container/debian-12-kernel-devel/Dockerfile
+++ b/container/debian-12-kernel-devel/Dockerfile
@@ -1,0 +1,27 @@
+ARG tag=12
+FROM debian:${tag}
+RUN apt-get -qq update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade --no-install-recommends \
+    bc \
+    bison \
+    build-essential \
+    ca-certificates \
+    cpio \
+    debhelper \
+    devscripts \
+    dkms \
+    flex \
+    git \
+    kmod \
+    libelf-dev \
+    libncurses-dev \
+    libssl-dev \
+    linux-image-generic \
+    linux-headers-generic \
+    openssl \
+    pkg-config \
+    python3 \
+    rsync \
+    wget \
+    zstd \
+    && apt-get clean

--- a/include/linux/spi/spi.h
+++ b/include/linux/spi/spi.h
@@ -11,9 +11,9 @@
 #include <linux/version.h>
 #include_next <linux/spi/spi.h>
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-/* spi_get_chipselect() was introduced in commit 9e264f3f85a5 ("spi: Replace
- * all spi->chip_select and spi->cs_gpiod references with function call").
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+/* spi_get_chipselect() was introduced in commit 303feb3cc06a ("spi: Add APIs
+ * in spi core to set/get spi->chip_select and spi->cs_gpiod").
  */
 static inline u8 spi_get_chipselect(const struct spi_device *spi, u8 idx)
 {

--- a/include/linux/spi/spi.h
+++ b/include/linux/spi/spi.h
@@ -11,7 +11,9 @@
 #include <linux/version.h>
 #include_next <linux/spi/spi.h>
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0) &&       \
+	(LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 71) || \
+	 LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0))
 /* spi_get_chipselect() was introduced in commit 303feb3cc06a ("spi: Add APIs
  * in spi core to set/get spi->chip_select and spi->cs_gpiod").
  */


### PR DESCRIPTION
spi_get_chipselect() was introduced in commit 303feb3cc06a ("spi: Add APIs in spi core to set/get spi->chip_select and spi->cs_gpiod").