### PR TITLE
backport: fix incomplete type kobject due to circular header dependency

### DIFF
--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -102,7 +102,7 @@ jobs:
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - name: Build modules
-      run: make KERNEL="$(basename /lib/modules/*)"
+      run: make -k KERNEL="$(basename /lib/modules/*)"
 
     - name: Install modules
       run: make KERNEL="$(basename /lib/modules/*)" install

--- a/drivers/fpga/dfl-afu-main.c
+++ b/drivers/fpga/dfl-afu-main.c
@@ -1024,7 +1024,11 @@ exit:
 	return ret;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int afu_remove(struct platform_device *pdev)
+#else
+static void afu_remove(struct platform_device *pdev)
+#endif
 {
 	dev_dbg(&pdev->dev, "%s\n", __func__);
 
@@ -1032,7 +1036,9 @@ static int afu_remove(struct platform_device *pdev)
 	dfl_fpga_dev_feature_uinit(pdev);
 	afu_dev_destroy(pdev);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0) || RHEL_RELEASE_CODE >= 0x803

--- a/drivers/fpga/dfl-fme-br.c
+++ b/drivers/fpga/dfl-fme-br.c
@@ -78,7 +78,11 @@ static int fme_br_probe(struct platform_device *pdev)
 	return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int fme_br_remove(struct platform_device *pdev)
+#else
+static void fme_br_remove(struct platform_device *pdev)
+#endif
 {
 	struct fpga_bridge *br = platform_get_drvdata(pdev);
 	struct fme_br_priv *priv = br->priv;
@@ -88,7 +92,9 @@ static int fme_br_remove(struct platform_device *pdev)
 	if (priv->port_ops)
 		dfl_fpga_port_ops_put(priv->port_ops);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static struct platform_driver fme_br_driver = {

--- a/drivers/fpga/dfl-fme-main.c
+++ b/drivers/fpga/dfl-fme-main.c
@@ -752,13 +752,19 @@ exit:
 	return ret;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int fme_remove(struct platform_device *pdev)
+#else
+static void fme_remove(struct platform_device *pdev)
+#endif
 {
 	dfl_fpga_dev_ops_unregister(pdev);
 	dfl_fpga_dev_feature_uinit(pdev);
 	fme_dev_destroy(pdev);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0) || RHEL_RELEASE_CODE >= 0x803

--- a/drivers/fpga/dfl-fme-region.c
+++ b/drivers/fpga/dfl-fme-region.c
@@ -61,7 +61,11 @@ eprobe_mgr_put:
 	return ret;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int fme_region_remove(struct platform_device *pdev)
+#else
+static void fme_region_remove(struct platform_device *pdev)
+#endif
 {
 	struct fpga_region *region = platform_get_drvdata(pdev);
 	struct fpga_manager *mgr = region->mgr;
@@ -69,7 +73,9 @@ static int fme_region_remove(struct platform_device *pdev)
 	fpga_region_unregister(region);
 	fpga_mgr_put(mgr);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static struct platform_driver fme_region_driver = {

--- a/drivers/fpga/dfl-platform.c
+++ b/drivers/fpga/dfl-platform.c
@@ -155,10 +155,16 @@ static int dfl_platform_probe(struct platform_device *pdev)
 	return ret;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int dfl_platform_remove(struct platform_device *pdev)
+#else
+static void dfl_platform_remove(struct platform_device *pdev)
+#endif
 {
 	dfl_platform_remove_feature_devs(pdev);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static const struct of_device_id dfl_platform_match[] = {

--- a/drivers/fpga/dfl-priv-feat-main.c
+++ b/drivers/fpga/dfl-priv-feat-main.c
@@ -102,7 +102,11 @@ exit:
 	return ret;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int dfl_priv_feat_remove(struct platform_device *pdev)
+#else
+static void dfl_priv_feat_remove(struct platform_device *pdev)
+#endif
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0) && RHEL_RELEASE_CODE < 0x803
 	device_remove_groups(&pdev->dev, dfl_priv_feat_dev_groups);
@@ -110,7 +114,9 @@ static int dfl_priv_feat_remove(struct platform_device *pdev)
 	dfl_fpga_dev_feature_uinit(pdev);
 	dfl_priv_feat_dev_destroy(pdev);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static struct platform_driver dfl_priv_feat_driver = {

--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -254,7 +254,11 @@ dfl_match_one_device(const struct dfl_device_id *id, struct dfl_device *ddev)
 	return NULL;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int dfl_bus_match(struct device *dev, struct device_driver *drv)
+#else
+static int dfl_bus_match(struct device *dev, const struct device_driver *drv)
+#endif
 {
 	struct dfl_device *ddev = to_dfl_dev(dev);
 	struct dfl_driver *ddrv = to_dfl_drv(drv);

--- a/drivers/fpga/intel-m10-bmc-sec-update.c
+++ b/drivers/fpga/intel-m10-bmc-sec-update.c
@@ -1664,7 +1664,11 @@ fw_name_fail:
 	return ret;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int m10bmc_sec_remove(struct platform_device *pdev)
+#else
+static void m10bmc_sec_remove(struct platform_device *pdev)
+#endif
 {
 	struct m10bmc_sec *sec = dev_get_drvdata(&pdev->dev);
 
@@ -1679,7 +1683,9 @@ static int m10bmc_sec_remove(struct platform_device *pdev)
 	kfree(sec->fw_name);
 	xa_erase(&fw_upload_xa, sec->fw_name_id);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static const struct platform_device_id intel_m10bmc_sec_ids[] = {

--- a/drivers/mfd/intel-m10-bmc-log.c
+++ b/drivers/mfd/intel-m10-bmc-log.c
@@ -240,7 +240,11 @@ error_exit:
 	return ret;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int m10bmc_log_remove(struct platform_device *pdev)
+#else
+static void m10bmc_log_remove(struct platform_device *pdev)
+#endif
 {
 	struct m10bmc_log *ddata = dev_get_drvdata(&pdev->dev);
 
@@ -248,7 +252,9 @@ static int m10bmc_log_remove(struct platform_device *pdev)
 
 	cancel_delayed_work_sync(&ddata->dwork);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static const struct m10bmc_log_cfg m10bmc_log_n6000_cfg = {

--- a/drivers/net/phy/intel-s10-phy.c
+++ b/drivers/net/phy/intel-s10-phy.c
@@ -530,12 +530,18 @@ static int intel_s10_phy_probe(struct platform_device *pdev)
 #endif
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int intel_s10_phy_remove(struct platform_device *pdev)
+#else
+static void intel_s10_phy_remove(struct platform_device *pdev)
+#endif
 {
 	struct hssi_phy *phy = dev_get_drvdata(&pdev->dev);
 
 	mutex_destroy(&phy->lock);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static struct platform_driver intel_s10_phy_driver = {

--- a/drivers/net/phy/qsfp-mem-platform.c
+++ b/drivers/net/phy/qsfp-mem-platform.c
@@ -75,7 +75,11 @@ exit:
 	return ret;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int qsfp_platform_remove(struct platform_device *pdev)
+#else
+static void qsfp_platform_remove(struct platform_device *pdev)
+#endif
 {
 	struct device *dev = &pdev->dev;
 	struct qsfp *qsfp = dev_get_drvdata(dev);
@@ -85,7 +89,9 @@ static int qsfp_platform_remove(struct platform_device *pdev)
 #endif
 	qsfp_remove_device(qsfp);
 	mutex_destroy(&qsfp->lock);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 	return 0;
+#endif
 }
 
 static const struct of_device_id intel_fpga_qsfp_mem_ids[] = {

--- a/include/linux/sysfs.h
+++ b/include/linux/sysfs.h
@@ -4,10 +4,10 @@
 #define BACKPORT_SYSFS_H
 
 #include <linux/version.h>
-#include <linux/mm.h>
 #include_next <linux/sysfs.h>
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 104) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))) && RHEL_RELEASE_CODE < 0x805
+#include <linux/mm.h>
 /**
  *	sysfs_emit - scnprintf equivalent, aware of PAGE_SIZE buffer
  *	@buf:	start of PAGE_SIZE buffer.


### PR DESCRIPTION
struct thpsize, which includes a member struct kobject kobj, was moved from mm/huge_memory.c to include/linux/huge_mm.h in commit 4b98995530b7 ("mm: shmem: add multi-size THP sysfs interface for anonymous shmem").

If include/linux/mm.h is included from include/linux/sysfs.h, this causes struct kobject to be incomplete when include/linux/huge_mm.h is parsed.

```
make[1]: Entering directory '/usr/src/kernels/6.11.0-0.rc2.20240809gitee9a43b7cfe2.27.fc41.x86_64'
  CC [M]  /__w/linux-dfl-backport/linux-dfl-backport/drivers/fpga/fpga-mgr.o
In file included from ./include/linux/mm.h:1127,
                 from /__w/linux-dfl-backport/linux-dfl-backport/include/linux/mm.h:14,
                 from /__w/linux-dfl-backport/linux-dfl-backport/include/linux/sysfs.h:7,
                 from ./include/linux/kobject.h:20,
                 from ./include/linux/energy_model.h:7,
                 from ./include/linux/device.h:16,
                 from /__w/linux-dfl-backport/linux-dfl-backport/include/linux/device.h:7,
                 from ./include/linux/platform_device.h:13,
                 from /__w/linux-dfl-backport/linux-dfl-backport/include/linux/fpga/fpga-mgr.h:12,
                 from /__w/linux-dfl-backport/linux-dfl-backport/drivers/fpga/fpga-mgr.c:12:
./include/linux/huge_mm.h:265:24: error: field 'kobj' has incomplete type
  265 |         struct kobject kobj;
      |                        ^~~~
```