### PR TITLE
fpga: dfl: fix kernel warning on port release/assign for SRIOV

### DIFF
--- a/drivers/fpga/dfl-afu-dma-region.c
+++ b/drivers/fpga/dfl-afu-dma-region.c
@@ -209,10 +209,9 @@ static int afu_dma_region_add(struct dfl_feature_dev_data *fdata,
 			      struct dfl_afu_dma_region *region)
 {
 	struct dfl_afu *afu = dfl_fpga_fdata_get_private(fdata);
-	struct device *dev = &fdata->dev->dev;
 	struct rb_node **new, *parent = NULL;
 
-	dev_dbg(dev, "add region (iova = %llx)\n", region->iova);
+	dev_dbg(&fdata->dev->dev, "add region (iova = %llx)\n", region->iova);
 
 	new = &afu->dma_regions.rb_node;
 
@@ -250,10 +249,9 @@ static int afu_dma_region_add(struct dfl_feature_dev_data *fdata,
 static void afu_dma_region_remove(struct dfl_feature_dev_data *fdata,
 				  struct dfl_afu_dma_region *region)
 {
-	struct device *dev = &fdata->dev->dev;
 	struct dfl_afu *afu;
 
-	dev_dbg(dev, "del region (iova = %llx)\n", region->iova);
+	dev_dbg(&fdata->dev->dev, "del region (iova = %llx)\n", region->iova);
 
 	afu = dfl_fpga_fdata_get_private(fdata);
 	rb_erase(&region->node, &afu->dma_regions);

--- a/drivers/fpga/dfl-afu-main.c
+++ b/drivers/fpga/dfl-afu-main.c
@@ -690,11 +690,9 @@ static struct dfl_feature_driver port_feature_drvs[] = {
 
 static int afu_open(struct inode *inode, struct file *filp)
 {
-	struct platform_device *fdev = dfl_fpga_inode_to_feature_dev(inode);
-	struct dfl_feature_dev_data *fdata;
+	struct dfl_feature_dev_data *fdata = dfl_fpga_inode_to_feature_dev_data(inode);
+	struct platform_device *fdev = fdata->dev;
 	int ret;
-
-	fdata = to_dfl_feature_dev_data(&fdev->dev);
 
 	mutex_lock(&fdata->lock);
 	ret = dfl_feature_dev_use_begin(fdata, filp->f_flags & O_EXCL);

--- a/drivers/fpga/dfl-afu-main.c
+++ b/drivers/fpga/dfl-afu-main.c
@@ -145,11 +145,9 @@ static u8 get_port_rev(struct dfl_feature_dev_data *fdata)
 
 static int port_reset(struct platform_device *pdev)
 {
-	struct dfl_feature_dev_data *fdata;
+	struct dfl_feature_dev_data *fdata = to_dfl_feature_dev_data(&pdev->dev);
 	int ret;
 	u8 rev;
-
-	fdata = to_dfl_feature_dev_data(&pdev->dev);
 
 	rev = get_port_rev(fdata);
 
@@ -548,7 +546,6 @@ static umode_t port_afu_attrs_visible(struct kobject *kobj,
 	struct dfl_feature_dev_data *fdata;
 
 	fdata = to_dfl_feature_dev_data(dev);
-
 	/*
 	 * sysfs entries are visible only if related private feature is
 	 * enumerated.
@@ -570,8 +567,7 @@ __ATTRIBUTE_GROUPS(port_afu);
 static int port_afu_init(struct platform_device *pdev,
 			 struct dfl_feature *feature)
 {
-	struct dfl_feature_dev_data *fdata =
-					to_dfl_feature_dev_data(&pdev->dev);
+	struct dfl_feature_dev_data *fdata = to_dfl_feature_dev_data(&pdev->dev);
 	struct resource *res = &pdev->resource[feature->resource_index];
 	int ret;
 
@@ -618,8 +614,7 @@ static const struct dfl_feature_ops port_afu_ops = {
 static int port_stp_init(struct platform_device *pdev,
 			 struct dfl_feature *feature)
 {
-	struct dfl_feature_dev_data *fdata =
-					to_dfl_feature_dev_data(&pdev->dev);
+	struct dfl_feature_dev_data *fdata = to_dfl_feature_dev_data(&pdev->dev);
 	struct resource *res = &pdev->resource[feature->resource_index];
 
 	return afu_mmio_region_add(fdata,

--- a/drivers/fpga/dfl-fme-main.c
+++ b/drivers/fpga/dfl-fme-main.c
@@ -632,7 +632,7 @@ static int fme_open(struct inode *inode, struct file *filp)
 	if (!ret) {
 		dev_dbg(&fdev->dev, "Device File Opened %d Times\n",
 			dfl_feature_dev_use_count(fdata));
-		filp->private_data = pdata;
+		filp->private_data = fdata;
 	}
 	mutex_unlock(&fdata->lock);
 
@@ -641,8 +641,7 @@ static int fme_open(struct inode *inode, struct file *filp)
 
 static int fme_release(struct inode *inode, struct file *filp)
 {
-	struct dfl_feature_platform_data *pdata = filp->private_data;
-	struct dfl_feature_dev_data *fdata = pdata->fdata;
+	struct dfl_feature_dev_data *fdata = filp->private_data;
 	struct platform_device *pdev = fdata->dev;
 	struct dfl_feature *feature;
 
@@ -662,8 +661,7 @@ static int fme_release(struct inode *inode, struct file *filp)
 
 static long fme_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
-	struct dfl_feature_platform_data *pdata = filp->private_data;
-	struct dfl_feature_dev_data *fdata = pdata->fdata;
+	struct dfl_feature_dev_data *fdata = filp->private_data;
 	struct platform_device *pdev = fdata->dev;
 	struct dfl_feature *f;
 	long ret;

--- a/drivers/fpga/dfl-fme-main.c
+++ b/drivers/fpga/dfl-fme-main.c
@@ -618,15 +618,10 @@ static long fme_ioctl_check_extension(struct dfl_feature_dev_data *fdata,
 
 static int fme_open(struct inode *inode, struct file *filp)
 {
-	struct platform_device *fdev = dfl_fpga_inode_to_feature_dev(inode);
-	struct dfl_feature_platform_data *pdata = dev_get_platdata(&fdev->dev);
-	struct dfl_feature_dev_data *fdata;
+	struct dfl_feature_dev_data *fdata = dfl_fpga_inode_to_feature_dev_data(inode);
+	struct platform_device *fdev = fdata->dev;
 	int ret;
 
-	if (WARN_ON(!pdata))
-		return -ENODEV;
-
-	fdata = pdata->fdata;
 	mutex_lock(&fdata->lock);
 	ret = dfl_feature_dev_use_begin(fdata, filp->f_flags & O_EXCL);
 	if (!ret) {

--- a/drivers/fpga/dfl-fme-pr.c
+++ b/drivers/fpga/dfl-fme-pr.c
@@ -361,8 +361,7 @@ static void dfl_fme_destroy_regions(struct dfl_feature_dev_data *fdata)
 static int pr_mgmt_init(struct platform_device *pdev,
 			struct dfl_feature *feature)
 {
-	struct dfl_feature_dev_data *fdata =
-			to_dfl_feature_dev_data(&pdev->dev);
+	struct dfl_feature_dev_data *fdata = to_dfl_feature_dev_data(&pdev->dev);
 	struct dfl_fme_region *fme_region;
 	struct dfl_fme_bridge *fme_br;
 	struct platform_device *mgr;
@@ -431,8 +430,7 @@ unlock:
 static void pr_mgmt_uinit(struct platform_device *pdev,
 			  struct dfl_feature *feature)
 {
-	struct dfl_feature_dev_data *fdata =
-			to_dfl_feature_dev_data(&pdev->dev);
+	struct dfl_feature_dev_data *fdata = to_dfl_feature_dev_data(&pdev->dev);
 
 	mutex_lock(&fdata->lock);
 

--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -939,7 +939,7 @@ err_free_id:
  */
 static int feature_dev_register(struct dfl_feature_dev_data *fdata)
 {
-	struct dfl_feature_platform_data pdata = { 0 };
+	struct dfl_feature_platform_data pdata = {};
 	struct platform_device *fdev;
 	struct dfl_feature *feature;
 	int ret;

--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -157,8 +157,7 @@ static LIST_HEAD(dfl_port_ops_list);
  *
  * Please note that must dfl_fpga_port_ops_put after use the port_ops.
  */
-struct dfl_fpga_port_ops *
-dfl_fpga_port_ops_get(struct dfl_feature_dev_data *fdata)
+struct dfl_fpga_port_ops *dfl_fpga_port_ops_get(struct dfl_feature_dev_data *fdata)
 {
 	struct dfl_fpga_port_ops *ops = NULL;
 
@@ -951,8 +950,7 @@ static int feature_dev_register(struct dfl_feature_dev_data *fdata)
 	fdata->dev = fdev;
 
 	fdev->dev.parent = &fdata->dfl_cdev->region->dev;
-	fdev->dev.devt = dfl_get_devt(dfl_devs[fdata->type].devt_type,
-				      fdev->id);
+	fdev->dev.devt = dfl_get_devt(dfl_devs[fdata->type].devt_type, fdev->id);
 
 	dfl_fpga_dev_for_each_feature(fdata, feature)
 		feature->dev = fdev;
@@ -1834,8 +1832,7 @@ EXPORT_SYMBOL_GPL(dfl_fpga_feature_devs_remove);
  */
 struct dfl_feature_dev_data *
 __dfl_fpga_cdev_find_port_data(struct dfl_fpga_cdev *cdev, void *data,
-			       int (*match)(struct dfl_feature_dev_data *,
-					    void *))
+			       int (*match)(struct dfl_feature_dev_data *, void *))
 {
 	struct dfl_feature_dev_data *fdata;
 
@@ -1902,7 +1899,6 @@ int dfl_fpga_cdev_release_port(struct dfl_fpga_cdev *cdev, int port_id)
 
 	feature_dev_unregister(fdata);
 	cdev->released_port_num++;
-
 unlock_exit:
 	mutex_unlock(&cdev->lock);
 	return ret;
@@ -1945,7 +1941,6 @@ int dfl_fpga_cdev_assign_port(struct dfl_fpga_cdev *cdev, int port_id)
 	mutex_unlock(&fdata->lock);
 
 	cdev->released_port_num--;
-
 unlock_exit:
 	mutex_unlock(&cdev->lock);
 	return ret;

--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -570,7 +570,6 @@ void dfl_fpga_dev_feature_uinit(struct platform_device *pdev)
 EXPORT_SYMBOL_GPL(dfl_fpga_dev_feature_uinit);
 
 static int dfl_feature_instance_init(struct platform_device *pdev,
-				     struct dfl_feature_platform_data *pdata,
 				     struct dfl_feature *feature,
 				     struct dfl_feature_driver *drv)
 {
@@ -631,8 +630,7 @@ static bool dfl_feature_drv_match(struct dfl_feature *feature,
 int dfl_fpga_dev_feature_init(struct platform_device *pdev,
 			      struct dfl_feature_driver *feature_drvs)
 {
-	struct dfl_feature_platform_data *pdata = dev_get_platdata(&pdev->dev);
-	struct dfl_feature_dev_data *fdata = pdata->fdata;
+	struct dfl_feature_dev_data *fdata = to_dfl_feature_dev_data(&pdev->dev);
 	struct dfl_feature_driver *drv = feature_drvs;
 	struct dfl_feature *feature;
 	int ret;
@@ -640,8 +638,7 @@ int dfl_fpga_dev_feature_init(struct platform_device *pdev,
 	while (drv->ops) {
 		dfl_fpga_dev_for_each_feature(fdata, feature) {
 			if (dfl_feature_drv_match(feature, drv)) {
-				ret = dfl_feature_instance_init(pdev, pdata,
-								feature, drv);
+				ret = dfl_feature_instance_init(pdev, feature, drv);
 				if (ret)
 					goto exit;
 			}

--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -873,8 +873,10 @@ binfo_create_feature_dev_data(struct build_feature_devs_info *binfo)
 			feature->params = devm_kmemdup(binfo->dev,
 						       finfo->params, finfo->param_size,
 						       GFP_KERNEL);
-			if (!feature->params)
-				return ERR_PTR(-ENOMEM);
+			if (!feature->params) {
+				ret = -ENOMEM;
+				goto err_free_id;
+			}
 
 			feature->param_size = finfo->param_size;
 		}

--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -553,8 +553,7 @@ EXPORT_SYMBOL_GPL(dfl_dev_get_base_dev);
  */
 void dfl_fpga_dev_feature_uinit(struct platform_device *pdev)
 {
-	struct dfl_feature_platform_data *pdata = dev_get_platdata(&pdev->dev);
-	struct dfl_feature_dev_data *fdata = pdata->fdata;
+	struct dfl_feature_dev_data *fdata = to_dfl_feature_dev_data(&pdev->dev);
 	struct dfl_feature *feature;
 
 	dfl_devs_remove(fdata);
@@ -2168,8 +2167,7 @@ long dfl_feature_ioctl_set_irq(struct platform_device *pdev,
 			       struct dfl_feature *feature,
 			       unsigned long arg)
 {
-	struct dfl_feature_platform_data *pdata = dev_get_platdata(&pdev->dev);
-	struct dfl_feature_dev_data *fdata = pdata->fdata;
+	struct dfl_feature_dev_data *fdata = to_dfl_feature_dev_data(&pdev->dev);
 	struct dfl_fpga_irq_set hdr;
 	s32 *fds;
 	long ret;

--- a/drivers/fpga/dfl.h
+++ b/drivers/fpga/dfl.h
@@ -230,8 +230,7 @@ struct dfl_fpga_port_ops {
 
 void dfl_fpga_port_ops_add(struct dfl_fpga_port_ops *ops);
 void dfl_fpga_port_ops_del(struct dfl_fpga_port_ops *ops);
-struct dfl_fpga_port_ops *
-	dfl_fpga_port_ops_get(struct dfl_feature_dev_data *fdata);
+struct dfl_fpga_port_ops *dfl_fpga_port_ops_get(struct dfl_feature_dev_data *fdata);
 void dfl_fpga_port_ops_put(struct dfl_fpga_port_ops *ops);
 int dfl_fpga_check_port_id(struct dfl_feature_dev_data *fdata, void *pport_id);
 
@@ -598,13 +597,11 @@ void dfl_fpga_feature_devs_remove(struct dfl_fpga_cdev *cdev);
 
 struct dfl_feature_dev_data *
 __dfl_fpga_cdev_find_port_data(struct dfl_fpga_cdev *cdev, void *data,
-			       int (*match)(struct dfl_feature_dev_data *,
-					    void *));
+			       int (*match)(struct dfl_feature_dev_data *, void *));
 
 static inline struct dfl_feature_dev_data *
 dfl_fpga_cdev_find_port_data(struct dfl_fpga_cdev *cdev, void *data,
-			     int (*match)(struct dfl_feature_dev_data *,
-					  void *))
+			     int (*match)(struct dfl_feature_dev_data *, void *))
 {
 	struct dfl_feature_dev_data *fdata;
 

--- a/drivers/fpga/dfl.h
+++ b/drivers/fpga/dfl.h
@@ -428,14 +428,14 @@ int dfl_fpga_dev_ops_register(struct platform_device *pdev,
 			      struct module *owner);
 void dfl_fpga_dev_ops_unregister(struct platform_device *pdev);
 
-static inline
-struct platform_device *dfl_fpga_inode_to_feature_dev(struct inode *inode)
+static inline struct dfl_feature_dev_data *
+dfl_fpga_inode_to_feature_dev_data(struct inode *inode)
 {
 	struct dfl_feature_platform_data *pdata;
 
 	pdata = container_of(inode->i_cdev, struct dfl_feature_platform_data,
 			     cdev);
-	return pdata->fdata->dev;
+	return pdata->fdata;
 }
 
 #define dfl_fpga_dev_for_each_feature(fdata, feature)			    \


### PR DESCRIPTION
Sync changes from upcoming resubmission of patch series ["fpga: dfl: fix kernel warning on port release/assign for SRIOV"](https://patchwork.kernel.org/project/linux-fpga/cover/20240409233942.828440-1-peter.colberg@intel.com/).