### PR TITLE
.github: workflows: restrict top-level workflow permissions

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,7 +1,8 @@
 name: Build kernel development containers
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
 permissions:
-  packages: write
+  contents: read
 
 on:
   push:
@@ -25,6 +26,9 @@ on:
 
 jobs:
   container:
+    permissions:
+      packages: write
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/dkms.yml
+++ b/.github/workflows/dkms.yml
@@ -1,5 +1,9 @@
 name: Build dkms packages
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -30,6 +34,9 @@ on:
 
 jobs:
   dkms:
+    permissions:
+      packages: read
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/modules.yml
+++ b/.github/workflows/modules.yml
@@ -1,5 +1,9 @@
 name: Build and install modules
 
+# https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -30,6 +34,9 @@ on:
 
 jobs:
   modules:
+    permissions:
+      packages: read
+
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Only permit reading the repository contents by default, and set further
privileges at the job level to satisfy OpenSSF Scorecard criteria.

Link: https://github.com/ossf/scorecard/blob/9ff40de429d0c7710076070387c8755494a9f187/docs/checks.md#token-permissions
Link: https://securityscorecards.dev/viewer/?uri=github.com/OFS/linux-dfl-backport