### PR TITLE
modpost: fix dfl MODULE_DEVICE_TABLE built on big-endian host

### DIFF
--- a/scripts/mod/file2alias.c
+++ b/scripts/mod/file2alias.c
@@ -1386,9 +1386,9 @@ static int do_dfl_entry(const char *filename, void *symval, char *alias)
 	guid_t null_guid = {0};
 	DEF_FIELD(symval, dfl_device_id, type);
 	DEF_FIELD(symval, dfl_device_id, feature_id);
-	DEF_FIELD(symval, dfl_device_id, guid);
+	DEF_FIELD_ADDR(symval, dfl_device_id, guid);
 
-	guid_cmp_val = memcmp(&null_guid, &guid, sizeof(guid_t));
+	guid_cmp_val = memcmp(&null_guid, guid, sizeof(guid_t));
 
 	if (feature_id == 0 && guid_cmp_val == 0) {
 		warn("Invalid dfl Device ID for in '%s'\n", filename);
@@ -1402,7 +1402,7 @@ static int do_dfl_entry(const char *filename, void *symval, char *alias)
 
 	if (guid_cmp_val) {
 		strcat(alias + strlen(alias), "g{");
-		add_guid(alias, guid);
+		add_guid(alias, *guid);
 		strcat(alias + strlen(alias), "}");
 	}
 	add_wildcard(alias);


### PR DESCRIPTION
When MODULE_DEVICE_TABLE(dfl, ) is built on a host with a different endianness from the target architecture, it results in an incorrect MODULE_ALIAS(). Refer to commit [ac96a15a0f0c ("modpost: fix ishtp MODULE_DEVICE_TABLE built on big-endian host")](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ac96a15a0f0c8812a3aaa587b871cd5527f6d736) for details.

This resolves a build failure after commit [a660deb0f1f6 ("modpost: detect endianness on run-time")](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a660deb0f1f62214439640292cd7726f6ed8023d), which fails to compile bswap() for the argument type guid_t since it is not __uint{16,32,64}_t.