### PR TITLE
fpga: dfl: Add GUID support in mod device table

### DIFF
--- a/Documentation/ABI/testing/sysfs-bus-dfl
+++ b/Documentation/ABI/testing/sysfs-bus-dfl
@@ -15,3 +15,12 @@ Description:	Read-only. It returns feature identifier local to its DFL FIU
 		type.
 
 		Format: 0x%x
+
+What:		/sys/bus/dfl/devices/dfl_dev.X/guid
+Date:		Nov 2023
+KernelVersion:	6.6
+Contact:	Basheer Ahmed Muddebihal <basheer.ahmed.muddebihal@linux.intel.com>
+Description:	Read-only. It returns DFL feature identifier in the form GUID
+		(8-4-4-4-12) if the feature header version is 1(DFHv1).
+
+		Format: 03020100-0504-0706-0809-0A0B0C0D0E0F (Little Endian)

--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -243,11 +243,23 @@ EXPORT_SYMBOL_GPL(dfl_fpga_check_port_id);
 
 static DEFINE_IDA(dfl_device_ida);
 
+static bool dfl_feature_id_is_match(const struct dfl_device_id *id, struct dfl_device *ddev)
+{
+	return id->type == ddev->type && id->feature_id == ddev->feature_id;
+}
+
+static bool dfl_guid_is_match(const char *guid_str, const guid_t *guid_dev)
+{
+	return dfl_guid_is_valid(guid_dev) && guid_parse_and_compare(guid_str, guid_dev);
+}
+
 static const struct dfl_device_id *
 dfl_match_one_device(const struct dfl_device_id *id, struct dfl_device *ddev)
 {
-	if ((dfl_guid_is_valid(&ddev->guid) && guid_equal(&id->guid, &ddev->guid)) ||
-	    (id->type == ddev->type && id->feature_id == ddev->feature_id))
+	if (dfl_guid_is_match(id->guid_string, &ddev->guid))
+		return id;
+
+	if (dfl_feature_id_is_match(id, ddev))
 		return id;
 
 	return NULL;
@@ -265,7 +277,7 @@ static int dfl_bus_match(struct device *dev, const struct device_driver *drv)
 
 	id_entry = ddrv->id_table;
 	if (id_entry) {
-		while (id_entry->feature_id || dfl_guid_is_valid(&id_entry->guid)) {
+		while (id_entry->feature_id || *id_entry->guid_string) {
 			if (dfl_match_one_device(id_entry, ddev)) {
 				ddev->id_entry = id_entry;
 				return 1;
@@ -315,12 +327,14 @@ static int dfl_bus_uevent(const struct device *dev, struct kobj_uevent_env *env)
 #else
 	const struct dfl_device *ddev = to_dfl_dev(dev);
 #endif
-	char alias[DFL_ALIAS_BUF_LEN];
+	char alias[sizeof("dfl:tXXXXfXXXXg{}") + UUID_STRING_LEN];
 
-	scnprintf(alias, DFL_ALIAS_BUF_LEN, "dfl:t%04Xf%04X", ddev->type, ddev->feature_id);
-
-	if (!guid_is_null(&ddev->guid))
-		scnprintf(alias + strlen(alias), DFL_ALIAS_BUF_LEN, "g{%pUL}", &ddev->guid);
+	if (guid_is_null(&ddev->guid))
+		snprintf(alias, sizeof("dfl:tXXXXfXXXX"), "dfl:t%04Xf%04X",
+			 ddev->type, ddev->feature_id);
+	else
+		snprintf(alias,sizeof("dfl:tXXXXfXXXXg{}") + UUID_STRING_LEN,
+				"dfl:t%04Xf%04Xg{%pUL}", ddev->type, ddev->feature_id, &ddev->guid);
 
 	return add_uevent_var(env, "MODALIAS=%s", alias);
 }
@@ -429,6 +443,9 @@ dfl_dev_add(struct dfl_feature_dev_data *fdata,
 		}
 		ddev->param_size = feature->param_size;
 	}
+
+	if (ddev->dfh_version == 1)
+		guid_copy(&ddev->guid, &feature->guid);
 
 	if (ddev->dfh_version == 1)
 		guid_copy(&ddev->guid, &feature->guid);
@@ -770,7 +787,7 @@ struct build_feature_devs_info {
  * @fid: id of this sub feature.
  * @revision: revision of this sub feature
  * @dfh_version: device feature header version.
- * @guid: guid of this sub feature.
+ * @guid: GUID of this sub feature.
  * @mmio_res: mmio resource of this sub feature.
  * @ioaddr: mapped base address of mmio resource.
  * @node: node in sub_features linked list.
@@ -1341,22 +1358,10 @@ create_feature_instance(struct build_feature_devs_info *binfo,
 
 		guid_l = readq(binfo->ioaddr + ofst + GUID_L);
 		guid_h = readq(binfo->ioaddr + ofst + GUID_H);
+		finfo->guid = dfl_guid_init(guid_h, guid_l);
+		dev_dbg(binfo->dev, "dfl: GUID_H = 0x%llx , GUID_L = 0x%llx\n GUID = %pUL\n",
+			guid_h, guid_l, &finfo->guid);
 
-		if (guid_l || guid_h) {
-			dev_dbg(binfo->dev, "dfl: GUID_H = 0x%llx , GUID_L = 0x%llx\n",
-				guid_h, guid_l);
-			finfo->guid = GUID_INIT(FIELD_GET(DFL_GUID_H_A, guid_h),
-						FIELD_GET(DFL_GUID_H_B, guid_h),
-					FIELD_GET(DFL_GUID_H_C, guid_h),
-					FIELD_GET(DFL_GUID_L_D0, guid_l),
-					FIELD_GET(DFL_GUID_L_D1, guid_l),
-					FIELD_GET(DFL_GUID_L_D2, guid_l),
-					FIELD_GET(DFL_GUID_L_D3, guid_l),
-					FIELD_GET(DFL_GUID_L_D4, guid_l),
-					FIELD_GET(DFL_GUID_L_D5, guid_l),
-					FIELD_GET(DFL_GUID_L_D6, guid_l),
-					FIELD_GET(DFL_GUID_L_D7, guid_l));
-		}
 	} else {
 		start = binfo->start + ofst;
 		end = start + size - 1;

--- a/drivers/fpga/dfl.h
+++ b/drivers/fpga/dfl.h
@@ -238,7 +238,7 @@ int dfl_fpga_check_port_id(struct dfl_feature_dev_data *fdata, void *pport_id);
  * struct dfl_feature_id - dfl private feature id
  *
  * @id: unique dfl private feature id.
- * @guid: unique dfl private guid.
+ * @guid: unique dfl private GUID.
  */
 struct dfl_feature_id {
 	u16 id;
@@ -284,6 +284,7 @@ struct dfl_feature_irq_ctx {
  * @ops: ops of this sub feature.
  * @ddev: ptr to the dfl device of this sub feature.
  * @priv: priv data of this feature.
+ * @guid: sub feature GUID.
  * @dfh_version: version of the DFH
  * @param_size: size of dfh parameters
  * @params: point to memory copy of dfh parameters
@@ -300,10 +301,10 @@ struct dfl_feature {
 	const struct dfl_feature_ops *ops;
 	struct dfl_device *ddev;
 	void *priv;
+	guid_t guid;
 	u8 dfh_version;
 	unsigned int param_size;
 	void *params;
-	guid_t guid;
 };
 
 #define FEATURE_DEV_ID_UNUSED	(-1)
@@ -507,34 +508,31 @@ static inline u8 dfl_feature_revision(void __iomem *base)
 	return (u8)FIELD_GET(DFH_REVISION, readq(base + DFH));
 }
 
-#define DFL_GUID_INVALID \
-	GUID_INIT(0xffffffff, 0xffff, 0xffff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff)
+#define DFL_GUID_INVALID						\
+	GUID_INIT(0xffffffff, 0xffff, 0xffff,				\
+		  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff)
 
 static inline bool dfl_guid_is_valid(const guid_t *guid)
 {
-	bool ret = true;
-	guid_t *guid_invalid =  &DFL_GUID_INVALID;
+	guid_t *guid_invalid = &DFL_GUID_INVALID;
 
-	if (guid_is_null(guid) || guid_equal(guid, guid_invalid))
-		ret = false;
-	return ret;
+	return !guid_is_null(guid) && !guid_equal(guid, guid_invalid);
 }
 
-/*
- *  Bit definitions masks extract from GUID_H and GUID_L
- *  GUID_INIT(a, b, c, d0, d1, d2, d3, d4, d5, d6, d7)
- */
-#define DFL_GUID_H_A   GENMASK_ULL(63, 32)
-#define DFL_GUID_H_B   GENMASK_ULL(31, 16)
-#define DFL_GUID_H_C   GENMASK_ULL(15, 0)
-#define DFL_GUID_L_D0  GENMASK_ULL(63, 56)
-#define DFL_GUID_L_D1  GENMASK_ULL(55, 48)
-#define DFL_GUID_L_D2  GENMASK_ULL(47, 40)
-#define DFL_GUID_L_D3  GENMASK_ULL(39, 32)
-#define DFL_GUID_L_D4  GENMASK_ULL(31, 24)
-#define DFL_GUID_L_D5  GENMASK_ULL(23, 16)
-#define DFL_GUID_L_D6  GENMASK_ULL(15, 8)
-#define DFL_GUID_L_D7  GENMASK_ULL(7, 0)
+static inline guid_t dfl_guid_init(u64 guid_h, u64 guid_l)
+{
+	return GUID_INIT(FIELD_GET(GENMASK_ULL(63, 32), guid_h),
+			 FIELD_GET(GENMASK_ULL(31, 16), guid_h),
+			 FIELD_GET(GENMASK_ULL(15, 0), guid_h),
+			 FIELD_GET(GENMASK_ULL(63, 56), guid_l),
+			 FIELD_GET(GENMASK_ULL(55, 48), guid_l),
+			 FIELD_GET(GENMASK_ULL(47, 40), guid_l),
+			 FIELD_GET(GENMASK_ULL(39, 32), guid_l),
+			 FIELD_GET(GENMASK_ULL(31, 24), guid_l),
+			 FIELD_GET(GENMASK_ULL(23, 16), guid_l),
+			 FIELD_GET(GENMASK_ULL(15, 8), guid_l),
+			 FIELD_GET(GENMASK_ULL(7, 0), guid_l));
+}
 
 /**
  * struct dfl_fpga_enum_info - DFL FPGA enumeration information

--- a/drivers/tty/serial/8250/8250_dfl.c
+++ b/drivers/tty/serial/8250/8250_dfl.c
@@ -150,12 +150,10 @@ static void dfl_uart_remove(struct dfl_device *dfl_dev)
 
 #define FME_FEATURE_ID_UART 0x24
 
-#define FME_GUID_UART \
-	GUID_INIT(0x9e6641a6, 0xca26, 0xcc04, 0xe1, 0xdf, \
-			0x0d, 0x4a, 0xce, 0x8e, 0x48, 0x6c)
+#define DFL_GUID_UART "9E6641A6-CA26-CC04-E1DF-0D4ACE8E486C"
 
 static const struct dfl_device_id dfl_uart_ids[] = {
-	{ FME_ID, FME_FEATURE_ID_UART, .guid = FME_GUID_UART },
+	{ FME_ID, FME_FEATURE_ID_UART, .guid_string = DFL_GUID_UART },
 	{ }
 };
 MODULE_DEVICE_TABLE(dfl, dfl_uart_ids);

--- a/include/linux/dfl.h
+++ b/include/linux/dfl.h
@@ -34,6 +34,7 @@ enum dfl_id_type {
  * @num_irqs: number of IRQs supported by this dfl device.
  * @cdev: pointer to DFL FPGA container device this dfl device belongs to.
  * @id_entry: matched id entry in dfl driver's id table.
+ * @guid: feature GUID of the dfl device.
  * @dfh_version: version of DFH for the device
  * @param_size: size of the block parameters in bytes
  * @params: pointer to block of parameters copied memory
@@ -50,10 +51,10 @@ struct dfl_device {
 	unsigned int num_irqs;
 	struct dfl_fpga_cdev *cdev;
 	const struct dfl_device_id *id_entry;
+	guid_t guid;
 	u8 dfh_version;
 	unsigned int param_size;
 	void *params;
-	guid_t guid;
 };
 
 /**

--- a/include/linux/mod_devicetable.h
+++ b/include/linux/mod_devicetable.h
@@ -28,13 +28,14 @@
  * @type: DFL FIU type of the device. See enum dfl_id_type.
  * @feature_id: feature identifier local to its DFL FIU type.
  * @driver_data: driver specific data.
+ * @guid_string: 36 char string of the form 03020100-0504-0706-0809-0A0B0C0D0E0F
  */
 #define dfl_device_id BACKPORT_dfl_device_id
 struct BACKPORT_dfl_device_id {
 	__u16 type;
 	__u16 feature_id;
-	guid_t guid;
 	kernel_ulong_t driver_data;
+	const char guid_string[UUID_STRING_LEN + 1];
 };
 
 #endif /* BACKPORT_LINUX_MOD_DEVICETABLE_H */

--- a/include/linux/uuid.h
+++ b/include/linux/uuid.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+#ifndef __BACKPORT_UUID_H
+#define __BACKPORT_UUID_H
+
+#include <linux/version.h>
+#include_next <linux/uuid.h>
+
+static inline
+bool guid_parse_and_compare(const char *string, const guid_t *guid)
+{
+	guid_t guid_input;
+	if (guid_parse(string, &guid_input))
+		return false;
+	return guid_equal(&guid_input, guid);
+}
+
+static inline
+bool uuid_parse_and_compare(const char *string, const uuid_t *uuid)
+{
+	uuid_t uuid_input;
+	if (uuid_parse(string, &uuid_input))
+		return false;
+	return uuid_equal(&uuid_input, uuid);
+}
+
+#endif

--- a/scripts/mod/devicetable-offsets.c
+++ b/scripts/mod/devicetable-offsets.c
@@ -246,7 +246,7 @@ int main(void)
 	DEVID(dfl_device_id);
 	DEVID_FIELD(dfl_device_id, type);
 	DEVID_FIELD(dfl_device_id, feature_id);
-	DEVID_FIELD(dfl_device_id, guid);
+	DEVID_FIELD(dfl_device_id, guid_string);
 
 	return 0;
 }

--- a/scripts/mod/file2alias.c
+++ b/scripts/mod/file2alias.c
@@ -1379,32 +1379,33 @@ static int do_mhi_entry(const char *filename, void *symval, char *alias)
 	return 1;
 }
 
-/* Looks like: dfl:tNfNg{guid} */
+/* Looks like: dfl:tNfNg{GUID} */
 static int do_dfl_entry(const char *filename, void *symval, char *alias)
 {
-	int guid_cmp_val;
-	guid_t null_guid = {0};
+	bool with_guid = true;
+	int len;
 	DEF_FIELD(symval, dfl_device_id, type);
 	DEF_FIELD(symval, dfl_device_id, feature_id);
-	DEF_FIELD_ADDR(symval, dfl_device_id, guid);
+	DEF_FIELD_ADDR(symval, dfl_device_id, guid_string);
 
-	guid_cmp_val = memcmp(&null_guid, guid, sizeof(guid_t));
+	if (__uuid_is_valid(*guid_string) < 0)
+	       with_guid = false;
 
-	if (feature_id == 0 && guid_cmp_val == 0) {
-		warn("Invalid dfl Device ID for in '%s'\n", filename);
+	if (feature_id == 0 && !with_guid) {
+		warn("Invalid dfl Device ID in '%s'\n", filename);
 		return 0;
 	}
 
 	if (feature_id == 0)
-		strcpy(alias, "dfl:t*f*");
+		len = snprintf(alias, ALIAS_SIZE, "dfl:t*f*");
 	else
-		snprintf(alias, ALIAS_SIZE, "dfl:t%04Xf%04X", type, feature_id);
+		len = snprintf(alias, ALIAS_SIZE, "dfl:t%04Xf%04X", type, feature_id);
 
-	if (guid_cmp_val) {
-		strcat(alias + strlen(alias), "g{");
-		add_guid(alias, *guid);
-		strcat(alias + strlen(alias), "}");
+	if (with_guid) {
+		__uuid_uppercase((char *)guid_string);
+		snprintf(alias + len, ALIAS_SIZE - len, "g{%s}", *guid_string);
 	}
+
 	add_wildcard(alias);
 	return 1;
 }


### PR DESCRIPTION
In the modalias table, dfl devices use the type id and feature id to create the dfl device string entry `"dfl:t0000f0009*"`. This patch adds support for the use of a GUID for dfl devices. Device drivers may match on type id and feature id, on the GUID, or on a combination of the type id, feature id and GUID.

If the feature id and GUID are both non-zero, then the modalias string is: `"dfl:t0000f0009g{03020100-0504-0706-0809-0A0B0C0D0E0F}*"` If the feature id is zero and the GUID is non-zero, then the string is: `"dfl:t*f*g{03020100-0504-0706-0809-0A0B0C0D0E0F}*"` If the feature id is non-zero and the GUID is zero, then the string is `"dfl:t0000f0009*"`

Followed the concept of the wmi device ID to define the GUID in string format and reuse the existing GUID infrastructure.