### PR TITLE
fpga: dfl: reset the device pointer of each sub feature

### DIFF
--- a/drivers/fpga/dfl.c
+++ b/drivers/fpga/dfl.c
@@ -974,15 +974,25 @@ static int feature_dev_register(struct dfl_feature_dev_data *fdata)
 
 err_put_dev:
 	platform_device_put(fdev);
+
 	fdata->dev = NULL;
+
+	dfl_fpga_dev_for_each_feature(fdata, feature)
+		feature->dev = NULL;
 
 	return ret;
 }
 
 static void feature_dev_unregister(struct dfl_feature_dev_data *fdata)
 {
+	struct dfl_feature *feature;
+
 	platform_device_unregister(fdata->dev);
+
 	fdata->dev = NULL;
+
+	dfl_fpga_dev_for_each_feature(fdata, feature)
+		feature->dev = NULL;
 }
 
 static int build_info_commit_dev(struct build_feature_devs_info *binfo)


### PR DESCRIPTION
In the functions feature_dev_register() and feature_dev_unregister(), reset the device pointer of each sub feature to NULL for consistency.

Link: https://patchwork.kernel.org/project/linux-fpga/patch/20241120011035.230574-16-peter.colberg@intel.com/