### PR TITLE
Backport to RHEL 9.5

### DIFF
--- a/drivers/fpga/dfl-cxl-cache.c
+++ b/drivers/fpga/dfl-cxl-cache.c
@@ -300,7 +300,7 @@ static long cxl_cache_set_region_read_only(struct dfl_cxl_cache *cxl_cache,
 
 	/* Mark the pages as non-cached and write-protected. */
 	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0) && RHEL_RELEASE_CODE < 0x905
 	vma->vm_flags &= ~VM_WRITE;
 #else
 	vm_flags_clear(vma, VM_WRITE);

--- a/include/linux/eventfd.h
+++ b/include/linux/eventfd.h
@@ -11,7 +11,7 @@
 #include <linux/version.h>
 #include_next <linux/eventfd.h>
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0) && RHEL_RELEASE_CODE < 0x905
 /* Before commit 3652117f8548 ("eventfd: simplify eventfd_signal()")
  * eventfd_signal() received an extra argument @n that was always 1.
  */

--- a/include/linux/spi/spi.h
+++ b/include/linux/spi/spi.h
@@ -11,9 +11,10 @@
 #include <linux/version.h>
 #include_next <linux/spi/spi.h>
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0) &&       \
-	(LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 71) || \
-	 LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0))
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0) &&        \
+	(LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 71) ||  \
+	 LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)) && \
+	RHEL_RELEASE_CODE < 0x905
 /* spi_get_chipselect() was introduced in commit 303feb3cc06a ("spi: Add APIs
  * in spi core to set/get spi->chip_select and spi->cs_gpiod").
  */


### PR DESCRIPTION
Resolve [build failure](https://github.com/OFS/linux-dfl-backport/actions/runs/12016737789/job/33497560450) with RHEL 9.5.