### PR TITLE
Backport to 6.13

### DIFF
--- a/drivers/spi/spi-altera-dfl.c
+++ b/drivers/spi/spi-altera-dfl.c
@@ -131,7 +131,7 @@ static int dfl_spi_altera_probe(struct dfl_device *dfl_dev)
 	void __iomem *base;
 	int err = -ENODEV;
 
-	host = spi_alloc_master(dev, sizeof(struct altera_spi));
+	host = spi_alloc_host(dev, sizeof(struct altera_spi));
 	if (!host)
 		return -ENOMEM;
 

--- a/drivers/spi/spi-altera-platform.c
+++ b/drivers/spi/spi-altera-platform.c
@@ -43,7 +43,7 @@ static int altera_spi_probe(struct platform_device *pdev)
 	int err = -ENODEV;
 	u16 i;
 
-	host = spi_alloc_master(&pdev->dev, sizeof(struct altera_spi));
+	host = spi_alloc_host(&pdev->dev, sizeof(struct altera_spi));
 	if (!host)
 		return err;
 

--- a/include/linux/spi/spi.h
+++ b/include/linux/spi/spi.h
@@ -24,4 +24,12 @@ static inline u8 spi_get_chipselect(const struct spi_device *spi, u8 idx)
 }
 #endif
 
+/* spi_alloc_host() and devm_spi_alloc_host() were introduced in commit
+ * b8d3b056a78d ("spi: introduce new helpers with using modern naming").
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0) && RHEL_RELEASE_CODE < 0x905
+#define spi_alloc_host spi_alloc_master
+#define devm_spi_alloc_host devm_spi_alloc_master
+#endif
+
 #endif /* _BACKPORT_LINUX_SPI_SPI_H_ */


### PR DESCRIPTION
This follows commit [0809a9ccac4a ("spi: remove {devm_}spi_alloc_master/slave()")](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0809a9ccac4a2ffdfd1561bb551aec6099775545) to fix [building against 6.13](https://github.com/OFS/linux-dfl-backport/actions/runs/12125919881/job/33806911155).

The cherry-picked upstream patches had been applied previously, but `spi_alloc_master()` was not replaced with `spi_alloc_host()` since the latter was only added in Linux 6.1.