### PR TITLE
backport: constify call to device_find_child() with Linux 6.14

### DIFF
--- a/drivers/net/ethernet/silicom/n5010-hssi.c
+++ b/drivers/net/ethernet/silicom/n5010-hssi.c
@@ -484,7 +484,11 @@ err_unreg_netdev:
 	return err;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0)
 static int n5010_match_phy_dev(struct device *dev, void *data)
+#else
+static int n5010_match_phy_dev(struct device *dev, const void *data)
+#endif
 {
 	return dev->driver && !strcmp(dev->driver->name, "n5010bmc-phy");
 }


### PR DESCRIPTION
Follow upstream commit [f1e8bf56320a](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f1e8bf56320a7fb32095b6c51b707459361b403b) ("driver core: Constify API device_find_child() and adapt for various usages"), which changes the second argument to the match function from `void *` to `const void *`.