### PR TITLE
Added check for RHEL 9.6+

### DIFF
--- a/include/linux/minmax.h
+++ b/include/linux/minmax.h
@@ -11,7 +11,7 @@
 #include_next <linux/minmax.h>
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0) && RHEL_RELEASE_CODE < 0x906
 static inline bool in_range64(u64 val, u64 start, u64 len)
 {
 	return (val - start) < len;

--- a/include/linux/minmax.h
+++ b/include/linux/minmax.h
@@ -11,7 +11,7 @@
 #include_next <linux/minmax.h>
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0) && RHEL_RELEASE_CODE < 0x906
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && RHEL_RELEASE_CODE < 0x906
 static inline bool in_range64(u64 val, u64 start, u64 len)
 {
 	return (val - start) < len;


### PR DESCRIPTION
Added a new check for version of RHEL >= 9.6, as they come with a kernel with in_range* already backported